### PR TITLE
Fixed README.md with missed vendor installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/log
 #### Code
 - To get started, you'll need JRuby with the Bundler gem installed.
 
-- Create a new plugin or clone and existing from the GitHub [logstash-plugins](https://github.com/logstash-plugins) organization. We also provide [example plugins](https://github.com/logstash-plugins?query=example).
+- Clone from the GitHub [logstash-plugins](https://github.com/logstash-plugins/logstash-integration-jdbc) organization.
+
+- Install vendor JDBC jars
+```sh
+./gradlew vendor
+```
 
 - Install dependencies
 ```sh
@@ -53,7 +58,7 @@ bundle exec rspec
 
 - Edit Logstash `Gemfile` and add the local plugin path, for example:
 ```ruby
-gem "logstash-filter-awesome", :path => "/your/local/logstash-filter-awesome"
+gem "logstash-integration-jdbc", :path => "/your/local/logstash-integration-jdbc"
 ```
 - Install plugin
 ```sh
@@ -66,7 +71,7 @@ bin/plugin install --no-verify
 ```
 - Run Logstash with your plugin
 ```sh
-bin/logstash -e 'filter {awesome {}}'
+bin/logstash -e 'filter {jdbc_streaming {}}'
 ```
 At this point any modifications to the plugin code will be applied to this local Logstash setup. After modifying the plugin, simply rerun Logstash.
 
@@ -76,7 +81,7 @@ You can use the same **2.1** method to run your plugin in an installed Logstash 
 
 - Build your plugin gem
 ```sh
-gem build logstash-filter-awesome.gemspec
+gem build logstash-integration-jdbc.gemspec
 ```
 - Install the plugin from the Logstash home
 ```sh


### PR DESCRIPTION
- added the listing of one missed step to build the plugin locally
- moved references from `filter-awesome` to this plugin name