### PR TITLE
Fix: driver loading when file not accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## N.X.T
+  - Fix: driver loading when file not accessible [#15](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/15)
+
 ## 5.0.0
   - Initial Release of JDBC Integration Plugin, incorporating [logstash-input-jdbc](https://github.com/logstash-plugins/logstash-input-jdbc), [logstash-filter-jdbc_streaming](https://github.com/logstash-plugins/logstash-filter-jdbc_streaming) and
     [logstash-filter-jdbc_static](https://github.com/logstash-plugins/logstash-filter-jdbc_static)

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -339,6 +339,7 @@ required you can pass them separated by a comma.
 NOTE: If not provided, Plugin will look for the driver class in the Logstash Java classpath. Additionally, if the library
  does not appear to be being loaded correctly via this setting, placing the relevant jar(s) in the Logstash Java
  classpath rather than via this setting may help.
+ Please also make sure the path is readable by the Logstash process (e.g. `logstash` user when running as a service).
 
 [id="plugins-{type}s-{plugin}-jdbc_fetch_size"]
 ===== `jdbc_fetch_size`

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -270,6 +270,7 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
   end
 
   def run(queue)
+    load_driver
     if @schedule
       @scheduler = Rufus::Scheduler.new(:max_work_threads => 1)
       @scheduler.cron @schedule do

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -139,47 +139,58 @@ module LogStash  module PluginMixins module Jdbc
 
     private
 
+    def load_driver
+      if @drivers_loaded.false?
+        require "java"
+        require "sequel"
+        require "sequel/adapters/jdbc"
+
+        load_driver_jars
+        begin
+          Sequel::JDBC.load_driver(@jdbc_driver_class)
+        rescue Sequel::AdapterNotFound => e # Sequel::AdapterNotFound, "#{@jdbc_driver_class} not loaded"
+          # fix this !!!
+          message = if jdbc_driver_library_set?
+                      "Are you sure you've included the correct jdbc driver in :jdbc_driver_library?"
+                    else
+                      ":jdbc_driver_library is not set, are you sure you included " +
+                          "the proper driver client libraries in your classpath?"
+                    end
+          raise LogStash::PluginLoadingError, "#{e}. #{message}"
+        end
+        @drivers_loaded.make_true
+      end
+    end
+
     def load_driver_jars
-      unless @jdbc_driver_library.nil? || @jdbc_driver_library.empty?
+      if jdbc_driver_library_set?
         @jdbc_driver_library.split(",").each do |driver_jar|
+          @logger.debug("loading #{driver_jar}")
+          # load 'driver.jar' is different than load 'some.rb' as it only causes the file to be added to
+          # JRuby's class-loader lookup (class) path - won't raise a LoadError when file is not readable
+          unless FileTest.readable?(driver_jar)
+            raise LogStash::PluginLoadingError, "unable to load #{driver_jar} from :jdbc_driver_library, " +
+                "file not readable (please check user and group permissions for the path)"
+          end
           begin
-            @logger.debug("loading #{driver_jar}")
-            # Use https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#from-jar-files to make classes from jar
-            # available
             require driver_jar
           rescue LoadError => e
             raise LogStash::PluginLoadingError, "unable to load #{driver_jar} from :jdbc_driver_library, #{e.message}"
+          rescue StandardError => e
+            raise LogStash::PluginLoadingError, "unable to load #{driver_jar} from :jdbc_driver_library, #{e}"
           end
         end
       end
     end
 
-    private
-    def open_jdbc_connection
-      require "java"
-      require "sequel"
-      require "sequel/adapters/jdbc"
+    def jdbc_driver_library_set?
+      !@jdbc_driver_library.nil? && !@jdbc_driver_library.empty?
+    end
 
+    def open_jdbc_connection
+      # at this point driver is already loaded
       Sequel.application_timezone = @plugin_timezone.to_sym
-      if @drivers_loaded.false?
-        begin
-          load_driver_jars
-          Sequel::JDBC.load_driver(@jdbc_driver_class)
-        rescue LogStash::Error => e
-          # raised in load_drivers, e.cause should be the caught Java exceptions
-          raise LogStash::PluginLoadingError, "#{e.message} and #{e.cause.message}"
-        rescue Sequel::AdapterNotFound => e
-          # fix this !!!
-          message = if @jdbc_driver_library.nil?
-            ":jdbc_driver_library is not set, are you sure you included
-                      the proper driver client libraries in your classpath?"
-          else
-            "Are you sure you've included the correct jdbc driver in :jdbc_driver_library?"
-          end
-          raise LogStash::PluginLoadingError, "#{e}. #{message}"
-        end
-        @drivers_loaded.make_true
-      end
+
       @database = jdbc_connect()
       @database.extension(:pagination)
       if @jdbc_default_timezone


### PR DESCRIPTION
these are non-critical improvements for (input) driver loading.

issues are kept on the original repo since they concern the plugin.
this is expected to resolve logstash-plugins/logstash-input-jdbc#369 
(also partially relates to logstash-plugins/logstash-input-jdbc#362)

*not sure these are worth "back-port"-ing, in any case there's a [draft](https://github.com/logstash-plugins/logstash-input-jdbc/pull/370)*