### PR TITLE
Fix tracking_column regression with Postgresql Numeric types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## N.X.T
-  - Fix: driver loading when file not accessible [#15](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/15)
+## 5.0.1
+  - Fixed tracking_column regression with Postgresql Numeric types [#17](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/17)
+  - Fixed driver loading when file not accessible [#15](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/15)
 
 ## 5.0.0
   - Initial Release of JDBC Integration Plugin, incorporating [logstash-input-jdbc](https://github.com/logstash-plugins/logstash-input-jdbc), [logstash-filter-jdbc_streaming](https://github.com/logstash-plugins/logstash-filter-jdbc_streaming) and

--- a/lib/logstash/plugin_mixins/jdbc/value_tracking.rb
+++ b/lib/logstash/plugin_mixins/jdbc/value_tracking.rb
@@ -62,7 +62,7 @@ module LogStash module PluginMixins module Jdbc
 
   class NumericValueTracker < ValueTracking
     def set_initial
-      common_set_initial(:gcd, 0)
+      common_set_initial(:abs, 0)
     end
 
     def set_value(value)

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.0.0'
+  s.version         = '5.0.1'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Prior to logsatash-input-jdbc 4.3.14, it was possible to use
the Postgresql Numeric type as a tracking column across Logstash
runs. Since 4.3.14, the deserialization of the sql_last_run
parameter has been broken for BigDecimal types, which is how
Numeric types are represented as Ruby BigDecimal objects by the
Sequel library we use in this plugin.

This commit restores this functionality.

Fixes: https://github.com/logstash-plugins/logstash-input-jdbc/issues/371

