### PR TITLE
Fix Integration Tests

### DIFF
--- a/ci/unit/docker-compose.yml
+++ b/ci/unit/docker-compose.yml
@@ -15,10 +15,13 @@ services:
       LS_JAVA_OPTS: "-Xmx256m -Xms256m"
       LOGSTASH_SOURCE: 1
       PG_CONNECTION_STRING: "jdbc:postgresql://postgresql:5432"
+      POSTGRES_PASSWORD: "test_user_password"
     tty: true
 
   postgresql:
     image: postgres:latest
+    environment:
+      POSTGRES_PASSWORD: "test_user_password"
     volumes:
     - ./setup.sql:/docker-entrypoint-initdb.d/init.sql
     ports:

--- a/spec/filters/integration/jdbc_static_spec.rb
+++ b/spec/filters/integration/jdbc_static_spec.rb
@@ -35,6 +35,7 @@ module LogStash module Filters
     let(:settings) do
       {
         "jdbc_user" => ENV['USER'],
+        "jdbc_password" => ENV["POSTGRES_PASSWORD"],
         "jdbc_driver_class" => "org.postgresql.Driver",
         "jdbc_driver_library" => "/usr/share/logstash/postgresql.jar",
         "staging_directory" => temp_import_path_plugin,
@@ -88,6 +89,7 @@ module LogStash module Filters
         let(:settings) do
           {
             "jdbc_user" => ENV['USER'],
+            "jdbc_password" => ENV["POSTGRES_PASSWORD"],
             "jdbc_driver_class" => "org.postgresql.Driver",
             "jdbc_driver_library" => "/usr/share/logstash/postgresql.jar",
             "staging_directory" => temp_import_path_plugin,

--- a/spec/filters/integration/jdbcstreaming_spec.rb
+++ b/spec/filters/integration/jdbcstreaming_spec.rb
@@ -16,7 +16,10 @@ module LogStash module Filters
       "jdbc:postgresql://postgresql:5432") + "/jdbc_streaming_db?user=postgres"
 
     let(:mixin_settings) do
-      { "jdbc_driver_class" => "org.postgresql.Driver",
+      {
+        "jdbc_user" => ENV['USER'],
+        "jdbc_password" => ENV["POSTGRES_PASSWORD"],
+        "jdbc_driver_class" => "org.postgresql.Driver",
         "jdbc_driver_library" => "/usr/share/logstash/postgresql.jar",
         "jdbc_connection_string" => jdbc_connection_string
       }

--- a/spec/filters/jdbc_streaming_spec.rb
+++ b/spec/filters/jdbc_streaming_spec.rb
@@ -1,4 +1,5 @@
 require "logstash/devutils/rspec/spec_helper"
+require "logstash/devutils/rspec/shared_examples"
 require "logstash/filters/jdbc_streaming"
 require 'jdbc/derby'
 require "sequel"

--- a/spec/inputs/integration/integ_spec.rb
+++ b/spec/inputs/integration/integ_spec.rb
@@ -19,6 +19,7 @@ describe LogStash::Inputs::Jdbc, :integration => true do
       "jdbc_connection_string" => jdbc_connection_string,
       "jdbc_driver_library" => "/usr/share/logstash/postgresql.jar",
       "jdbc_user" => "postgres",
+      "jdbc_password" => ENV["POSTGRES_PASSWORD"],
       "statement" => 'SELECT FIRST_NAME, LAST_NAME FROM "employee" WHERE EMP_NO = 2'
     }
   end

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
+require "logstash/devutils/rspec/shared_examples"
 require "logstash/inputs/jdbc"
 require "jdbc/derby"
 require "sequel"


### PR DESCRIPTION
Integration tests were failing due to a behavioural change in a
patch release of the postgres docker image, which now requires
a password to be set, or an explicit ENV setting to not require this.

This commit also fixes tests that were broken due to the changes to
devutils 2.0


