### PR TITLE
Fix prepared statement reconnect issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.2
+## 5.0.3
   - Fixed issue where a lost connection to the database can cause errors when using prepared statements with the scheduler [#25](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/25)
 
 ## 5.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 5.0.2
+  - Fixed issue where a lost connection to the database can cause errors when using prepared statements with the scheduler [#25](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/25)
+
+## 5.0.2
   - Fixed potential resource leak by ensuring scheduler is shutdown when a pipeline encounter an error during the running [#28](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/28)
-  
+
 ## 5.0.1
   - Fixed tracking_column regression with Postgresql Numeric types [#17](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/17)
   - Fixed driver loading when file not accessible [#15](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/15)

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -260,7 +260,9 @@ module LogStash  module PluginMixins module Jdbc
         end
         success = true
       rescue Sequel::DatabaseConnectionError, Sequel::DatabaseError, Java::JavaSql::SQLException => e
-        @logger.warn("Exception when executing JDBC query", :exception => e)
+        details = { :exception => e.message }
+        details[:backtrace] = e.backtrace if @logger.debug?
+        @logger.warn("Exception when executing JDBC query", details)
       else
         @value_tracker.set_value(sql_last_value)
       ensure

--- a/lib/logstash/plugin_mixins/jdbc/statement_handler.rb
+++ b/lib/logstash/plugin_mixins/jdbc/statement_handler.rb
@@ -97,7 +97,14 @@ module LogStash module PluginMixins module Jdbc
       end
       bind_value_sql_last_value(sql_last_value)
       statement_logger.log_statement_parameters(statement, parameters, nil)
-      db.call(name, parameters)
+      begin
+        db.call(name, parameters)
+      rescue => e
+        # clear the statement prepared flag - the statement may be closed by this
+        # time.
+        statement_prepared.make_false
+        raise e
+      end
     end
 
     def post_init(plugin)

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.0.2'
+  s.version         = '5.0.3'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/integration/integ_spec.rb
+++ b/spec/inputs/integration/integ_spec.rb
@@ -3,7 +3,6 @@ require "logstash/inputs/jdbc"
 require "sequel"
 require "sequel/adapters/jdbc"
 
-# This test requires: Firebird installed to Mac OSX, it uses the built-in example database `employee`
 
 describe LogStash::Inputs::Jdbc, :integration => true do
   # This is a necessary change test-wide to guarantee that no local timezone


### PR DESCRIPTION
This commit fixes an issue where, if the connection between Logstash
and the database fails due to an attempt to use a closed prepared statement.
This results in subsequent attempts to use a prepared statement
failing when using scheduling, which can only be rectified by restarting Logstash.

This commit resets the `statement_prepared` flag, which means that the
prepared statement will be recreated upon the next scheduled run.

This commit also adds a backtrace to log entries when this issue occurs to provide
more visibility into the cause of the issue.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
