### PR TITLE
Implemented close method to release scheduler resources on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.2
+  - Fixed potential resource leak by ensuring scheduler is shutdown when a pipeline encounter an error during the running [#28](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/28)
+  
 ## 5.0.1
   - Fixed tracking_column regression with Postgresql Numeric types [#17](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/17)
   - Fixed driver loading when file not accessible [#15](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/15)

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -283,6 +283,10 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
     end
   end # def run
 
+  def close
+    @scheduler.shutdown if @scheduler
+  end
+
   def stop
     close_jdbc_connection
     @scheduler.shutdown(:wait) if @scheduler

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.0.1'
+  s.version         = '5.0.2'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -191,6 +191,18 @@ describe LogStash::Inputs::Jdbc do
       Timecop.return
     end
 
+    it "cleans up scheduler resources on close" do
+      runner = Thread.new do
+        plugin.run(queue)
+      end
+      sleep 1
+      plugin.do_close
+
+      scheduler = plugin.instance_variable_get(:@scheduler)
+      expect(scheduler).to_not be_nil
+      expect(scheduler.down?).to be_truthy
+    end
+
   end
 
   context "when scheduling and previous runs are to be preserved" do


### PR DESCRIPTION
Close method is used to clean in case of error in run phase of the plugin, implemented to avoid leak of threads generated by Rufus scheduler.

Fixes #21
