### PR TITLE
Fix jdbc_fetch_size with postgresql

### DIFF
--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -144,6 +144,7 @@ module LogStash  module PluginMixins module Jdbc
         require "java"
         require "sequel"
         require "sequel/adapters/jdbc"
+        require "sequel/adapters/jdbc/transactions"
 
         load_driver_jars
         begin
@@ -193,6 +194,7 @@ module LogStash  module PluginMixins module Jdbc
 
       @database = jdbc_connect()
       @database.extension(:pagination)
+      @database.extend(Sequel::JDBC::Transactions)
       if @jdbc_default_timezone
         @database.extension(:named_timezones)
         @database.timezone = @jdbc_default_timezone

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1020,7 +1020,6 @@ describe LogStash::Inputs::Jdbc do
       {
         "statement" => "SELECT * FROM test_table",
         "jdbc_pool_timeout" => 0,
-        "jdbc_connection_string" => 'mock://localhost:1527/db',
         "sequel_opts" => {
           "max_connections" => 1
         }
@@ -1076,7 +1075,7 @@ describe LogStash::Inputs::Jdbc do
     end
 
     it "should report the statements to logging" do
-      expect(plugin.logger).to receive(:debug).once
+      expect(plugin.logger).to receive(:debug).thrice
       plugin.run(queue)
     end
   end


### PR DESCRIPTION
Port from old library to new: https://github.com/logstash-plugins/logstash-input-jdbc/pull/368

According to documentation (https://jdbc.postgresql.org/documentation/head/query.html) we need autocommit disabled. Work around is to create transaction and rollback always.

