### PR TITLE
driver loading: provide loaded driver to Sequel::connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.4
+  - Fixed issue where JDBC Drivers that don't correctly register with Java's DriverManager fail to load (such as Sybase) [#34](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/34)
+
 ## 5.0.3
   - Fixed issue where a lost connection to the database can cause errors when using prepared statements with the scheduler [#25](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/25)
 

--- a/lib/logstash/filters/jdbc/basic_database.rb
+++ b/lib/logstash/filters/jdbc/basic_database.rb
@@ -95,7 +95,7 @@ module LogStash module Filters module Jdbc
       end
       begin
         db = nil
-        ::Sequel::JDBC.load_driver(driver_class)
+        @options_hash[:driver] = ::Sequel::JDBC.load_driver(driver_class)
         @connection_string = connection_string
         if user
           @options_hash[:user] = user

--- a/lib/logstash/plugin_mixins/jdbc_streaming.rb
+++ b/lib/logstash/plugin_mixins/jdbc_streaming.rb
@@ -84,7 +84,7 @@ module LogStash module PluginMixins module JdbcStreaming
     @sequel_opts_symbols[:user] = @jdbc_user unless @jdbc_user.nil? || @jdbc_user.empty?
     @sequel_opts_symbols[:password] = @jdbc_password.value unless @jdbc_password.nil?
 
-    Sequel::JDBC.load_driver(@jdbc_driver_class)
+    @sequel_opts_symbols[:driver] = Sequel::JDBC.load_driver(@jdbc_driver_class)
     @database = Sequel.connect(@jdbc_connection_string, @sequel_opts_symbols)
     if @jdbc_validate_connection
       @database.extension(:connection_validator)

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.0.3'
+  s.version         = '5.0.4'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/jdbc/read_only_database_spec.rb
+++ b/spec/filters/jdbc/read_only_database_spec.rb
@@ -10,28 +10,37 @@ module LogStash module Filters module Jdbc
     let(:driver_class) { "org.apache.derby.jdbc.EmbeddedDriver" }
     let(:driver_library) { nil }
     subject(:read_only_db) { described_class.create(connection_string, driver_class, driver_library) }
+    let(:stub_driver_class) { double(driver_class).as_null_object }
 
     describe "basic operations" do
       describe "initializing" do
+        before(:each) do
+          allow(Sequel::JDBC).to receive(:load_driver).and_return(stub_driver_class)
+        end
+
         it "tests the connection with defaults" do
           expect(Sequel::JDBC).to receive(:load_driver).once.with(driver_class)
-          expect(Sequel).to receive(:connect).once.with(connection_string, {:test => true})
+          expect(Sequel).to receive(:connect).once.with(connection_string, {:test => true, :driver => stub_driver_class})
           expect(read_only_db.empty_record_set).to eq([])
         end
 
-        it "tests the connection with fully specified arguments" do
-          connection_str = "a connection string"
-          user = "a user"
-          password = Util::Password.new("secret")
-          expect(Sequel::JDBC).to receive(:load_driver).once.with("a driver class")
-          expect(Sequel).to receive(:connect).once.with(connection_str, {:user => user, :password =>  password.value, :test => true}).and_return(db)
-          described_class.create(connection_str, "a driver class", nil, user, password)
+        context 'with fully-specified arguments' do
+          let(:connection_string) { "a connection string" }
+          let(:user) { "a user" }
+          let(:password) { Util::Password.new("secret") }
+          let(:driver_class) { "a driver class" }
+
+          it "tests the connection" do
+            expect(Sequel::JDBC).to receive(:load_driver).once.with(driver_class)
+            expect(Sequel).to receive(:connect).once.with(connection_string, {:user => user, :password =>  password.value, :test => true, :driver => stub_driver_class}).and_return(db)
+            described_class.create(connection_string, driver_class, nil, user, password)
+          end
         end
 
         it "connects with defaults" do
           expect(Sequel::JDBC).to receive(:load_driver).once.with(driver_class)
-          expect(Sequel).to receive(:connect).once.with(connection_string, {:test => true}).and_return(db)
-          expect(Sequel).to receive(:connect).once.with(connection_string, {}).and_return(db)
+          expect(Sequel).to receive(:connect).once.with(connection_string, {:test => true, :driver => stub_driver_class}).and_return(db)
+          expect(Sequel).to receive(:connect).once.with(connection_string, {:driver => stub_driver_class}).and_return(db)
           expect(read_only_db.connected?).to be_falsey
           read_only_db.connect("a caller specific error message")
           expect(read_only_db.connected?).to be_truthy

--- a/spec/filters/jdbc/read_write_database_spec.rb
+++ b/spec/filters/jdbc/read_write_database_spec.rb
@@ -16,10 +16,11 @@ module LogStash module Filters module Jdbc
     describe "basic operations" do
       context "connecting  to a db" do
         it "connects with defaults" do
-          expect(::Sequel::JDBC).to receive(:load_driver).once.with("org.apache.derby.jdbc.EmbeddedDriver")
+          stub_driver_class = double('org.apache.derby.jdbc.EmbeddedDriver').as_null_object
+          expect(::Sequel::JDBC).to receive(:load_driver).once.with("org.apache.derby.jdbc.EmbeddedDriver").and_return(stub_driver_class)
           # two calls to connect because ReadWriteDatabase does verify_connection and connect
-          expect(::Sequel).to receive(:connect).once.with(connection_string_regex, {:test => true}).and_return(db)
-          expect(::Sequel).to receive(:connect).once.with(connection_string_regex, {}).and_return(db)
+          expect(::Sequel).to receive(:connect).once.with(connection_string_regex, {:driver => stub_driver_class, :test => true}).and_return(db)
+          expect(::Sequel).to receive(:connect).once.with(connection_string_regex, {:driver => stub_driver_class}).and_return(db)
           expect(read_write_db.empty_record_set).to eq([])
         end
 
@@ -27,9 +28,10 @@ module LogStash module Filters module Jdbc
           connection_str = "a connection string"
           user = "a user"
           password = Util::Password.new("secret")
-          expect(::Sequel::JDBC).to receive(:load_driver).once.with("a driver class")
-          expect(::Sequel).to receive(:connect).once.with(connection_str, {:user => user, :password => password.value, :test => true}).and_return(db)
-          expect(::Sequel).to receive(:connect).once.with(connection_str, {:user => user, :password => password.value}).and_return(db)
+          stub_driver_class = double('com.example.Driver')
+          expect(::Sequel::JDBC).to receive(:load_driver).once.with("a driver class").and_return(stub_driver_class)
+          expect(::Sequel).to receive(:connect).once.with(connection_str, {:driver => stub_driver_class, :user => user, :password => password.value, :test => true}).and_return(db)
+          expect(::Sequel).to receive(:connect).once.with(connection_str, {:driver => stub_driver_class, :user => user, :password => password.value}).and_return(db)
           described_class.create(connection_str, "a driver class", nil, user, password)
         end
       end


### PR DESCRIPTION
`Sequel::connect` will first attempt to auto-detect the driver based on the
jdbc connection URI, and will [fall-back][] to the driver given as `opts[:driver]`
when auto-detection fails.

By memoizing the loaded driver from our previous `Sequel::JDBC::load_driver`
and providing it to `Sequel::connect`, we provide one more chance for loading
to work.

This specifically seems to be the only path forward for Sybase drivers, whose
jdbc connection strings begin with `jdbc:sybase:Tds:` but use the driver with
path `com.sybase.jdbc4.jdbc.SybDriver`.

[fall-back]: https://github.com/jeremyevans/sequel/blob/5.19.0/lib/sequel/adapters/jdbc.rb#L211-L213