### PR TITLE
Fix: properly pass (symbolized) sequel opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.5
+  - Fixed user sequel_opts not being passed down properly [#37](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/37)
+  - Refactored jdbc_streaming to share driver loading, so the fixes from the jdbc plugin also effect jdbc_streaming
+
 ## 5.0.4
   - Fixed issue where JDBC Drivers that don't correctly register with Java's DriverManager fail to load (such as Sybase) [#34](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/34)
 

--- a/lib/logstash/filters/jdbc_streaming.rb
+++ b/lib/logstash/filters/jdbc_streaming.rb
@@ -46,6 +46,7 @@ require "lru_redux"
 # }
 #
 module LogStash module Filters class JdbcStreaming < LogStash::Filters::Base
+  include LogStash::PluginMixins::Jdbc::Common
   include LogStash::PluginMixins::JdbcStreaming
 
   config_name "jdbc_streaming"

--- a/lib/logstash/filters/jdbc_streaming.rb
+++ b/lib/logstash/filters/jdbc_streaming.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
+require "logstash/plugin_mixins/jdbc/common"
 require "logstash/plugin_mixins/jdbc_streaming"
 require "logstash/plugin_mixins/jdbc_streaming/cache_payload"
 require "logstash/plugin_mixins/jdbc_streaming/statement_handler"

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/inputs/base"
 require "logstash/namespace"
+require "logstash/plugin_mixins/jdbc/common"
 require "logstash/plugin_mixins/jdbc/jdbc"
 
 # this require_relative returns early unless the JRuby version is between 9.2.0.0 and 9.2.8.0

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -126,6 +126,7 @@ require_relative "tzinfo_jruby_patch"
 # ---------------------------------------------------------------------------------------------------
 #
 module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
+  include LogStash::PluginMixins::Jdbc::Common
   include LogStash::PluginMixins::Jdbc::Jdbc
   config_name "jdbc"
 

--- a/lib/logstash/plugin_mixins/jdbc/common.rb
+++ b/lib/logstash/plugin_mixins/jdbc/common.rb
@@ -1,0 +1,31 @@
+
+module LogStash module PluginMixins module Jdbc
+  module Common
+
+    def load_driver_jars
+      if jdbc_driver_library_set?
+        @jdbc_driver_library.split(",").each do |driver_jar|
+          @logger.debug("loading #{driver_jar}")
+          # load 'driver.jar' is different than load 'some.rb' as it only causes the file to be added to
+          # JRuby's class-loader lookup (class) path - won't raise a LoadError when file is not readable
+          unless FileTest.readable?(driver_jar)
+            raise LogStash::PluginLoadingError, "unable to load #{driver_jar} from :jdbc_driver_library, " +
+                "file not readable (please check user and group permissions for the path)"
+          end
+          begin
+            require driver_jar
+          rescue LoadError => e
+            raise LogStash::PluginLoadingError, "unable to load #{driver_jar} from :jdbc_driver_library, #{e.message}"
+          rescue StandardError => e
+            raise LogStash::PluginLoadingError, "unable to load #{driver_jar} from :jdbc_driver_library, #{e}"
+          end
+        end
+      end
+    end
+
+    def jdbc_driver_library_set?
+      !@jdbc_driver_library.nil? && !@jdbc_driver_library.empty?
+    end
+
+  end
+end end end

--- a/lib/logstash/plugin_mixins/jdbc/common.rb
+++ b/lib/logstash/plugin_mixins/jdbc/common.rb
@@ -4,6 +4,14 @@ module LogStash module PluginMixins module Jdbc
 
     private
 
+    def complete_sequel_opts(defaults = {})
+      sequel_opts = defaults.merge Hash[ @sequel_opts.map { |key,val| [key.is_a?(String) ? key.to_sym : key, val] } ]
+      sequel_opts[:user] = @jdbc_user unless @jdbc_user.nil? || @jdbc_user.empty?
+      sequel_opts[:password] = @jdbc_password.value unless @jdbc_password.nil?
+      sequel_opts[:driver] = @driver_impl # Sequel uses this as a fallback, if given URI doesn't auto-load the driver correctly
+      sequel_opts
+    end
+
     def load_driver
       return @driver_impl if @driver_impl ||= nil
 

--- a/lib/logstash/plugin_mixins/jdbc/common.rb
+++ b/lib/logstash/plugin_mixins/jdbc/common.rb
@@ -5,7 +5,10 @@ module LogStash module PluginMixins module Jdbc
     private
 
     def complete_sequel_opts(defaults = {})
-      sequel_opts = defaults.merge Hash[ @sequel_opts.map { |key,val| [key.is_a?(String) ? key.to_sym : key, val] } ]
+      sequel_opts = @sequel_opts.
+          map { |key,val| [key.is_a?(String) ? key.to_sym : key, val] }.
+          map { |key,val| [key, val.eql?('true') ? true : (val.eql?('false') ? false : val)] }
+      sequel_opts = defaults.merge Hash[sequel_opts]
       sequel_opts[:user] = @jdbc_user unless @jdbc_user.nil? || @jdbc_user.empty?
       sequel_opts[:password] = @jdbc_password.value unless @jdbc_password.nil?
       sequel_opts[:driver] = @driver_impl # Sequel uses this as a fallback, if given URI doesn't auto-load the driver correctly

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -138,31 +138,6 @@ module LogStash  module PluginMixins module Jdbc
       end
     end
 
-    private
-
-    def load_driver
-      if @drivers_loaded.false?
-        require "java"
-        require "sequel"
-        require "sequel/adapters/jdbc"
-
-        load_driver_jars
-        begin
-          @driver_impl = Sequel::JDBC.load_driver(@jdbc_driver_class)
-        rescue Sequel::AdapterNotFound => e # Sequel::AdapterNotFound, "#{@jdbc_driver_class} not loaded"
-          # fix this !!!
-          message = if jdbc_driver_library_set?
-                      "Are you sure you've included the correct jdbc driver in :jdbc_driver_library?"
-                    else
-                      ":jdbc_driver_library is not set, are you sure you included " +
-                          "the proper driver client libraries in your classpath?"
-                    end
-          raise LogStash::PluginLoadingError, "#{e}. #{message}"
-        end
-        @drivers_loaded.make_true
-      end
-    end
-
     def open_jdbc_connection
       # at this point driver is already loaded
       Sequel.application_timezone = @plugin_timezone.to_sym
@@ -205,7 +180,6 @@ module LogStash  module PluginMixins module Jdbc
     public
     def prepare_jdbc_connection
       @connection_lock = ReentrantLock.new
-      @drivers_loaded = Concurrent::AtomicBoolean.new
     end
 
     public

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -163,31 +163,6 @@ module LogStash  module PluginMixins module Jdbc
       end
     end
 
-    def load_driver_jars
-      if jdbc_driver_library_set?
-        @jdbc_driver_library.split(",").each do |driver_jar|
-          @logger.debug("loading #{driver_jar}")
-          # load 'driver.jar' is different than load 'some.rb' as it only causes the file to be added to
-          # JRuby's class-loader lookup (class) path - won't raise a LoadError when file is not readable
-          unless FileTest.readable?(driver_jar)
-            raise LogStash::PluginLoadingError, "unable to load #{driver_jar} from :jdbc_driver_library, " +
-                "file not readable (please check user and group permissions for the path)"
-          end
-          begin
-            require driver_jar
-          rescue LoadError => e
-            raise LogStash::PluginLoadingError, "unable to load #{driver_jar} from :jdbc_driver_library, #{e.message}"
-          rescue StandardError => e
-            raise LogStash::PluginLoadingError, "unable to load #{driver_jar} from :jdbc_driver_library, #{e}"
-          end
-        end
-      end
-    end
-
-    def jdbc_driver_library_set?
-      !@jdbc_driver_library.nil? && !@jdbc_driver_library.empty?
-    end
-
     def open_jdbc_connection
       # at this point driver is already loaded
       Sequel.application_timezone = @plugin_timezone.to_sym

--- a/lib/logstash/plugin_mixins/jdbc_streaming.rb
+++ b/lib/logstash/plugin_mixins/jdbc_streaming.rb
@@ -59,12 +59,7 @@ module LogStash module PluginMixins module JdbcStreaming
   def prepare_jdbc_connection
     load_driver
 
-    sequel_opts = @sequel_opts.inject({}) {|hash, (k,v)| hash[k.to_sym] = v; hash}
-    sequel_opts[:user] = @jdbc_user unless @jdbc_user.nil? || @jdbc_user.empty?
-    sequel_opts[:password] = @jdbc_password.value unless @jdbc_password.nil?
-    sequel_opts[:driver] = @driver_impl
-
-    @database = Sequel.connect(@jdbc_connection_string, sequel_opts)
+    @database = Sequel.connect(@jdbc_connection_string, complete_sequel_opts)
     if @jdbc_validate_connection
       @database.extension(:connection_validator)
       @database.pool.connection_validation_timeout = @jdbc_validation_timeout

--- a/lib/logstash/plugin_mixins/jdbc_streaming.rb
+++ b/lib/logstash/plugin_mixins/jdbc_streaming.rb
@@ -55,23 +55,6 @@ module LogStash module PluginMixins module JdbcStreaming
     config :jdbc_validation_timeout, :validate => :number, :default => 3600
   end
 
-  private
-
-  def load_driver_jars
-    unless @jdbc_driver_library.nil? || @jdbc_driver_library.empty?
-      @jdbc_driver_library.split(",").each do |driver_jar|
-        begin
-          @logger.debug("loading #{driver_jar}")
-          # Use https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#from-jar-files to make classes from jar
-          # available
-          require driver_jar
-        rescue LoadError => e
-          raise LogStash::PluginLoadingError, "unable to load #{driver_jar} from :jdbc_driver_library, #{e.message}"
-        end
-      end
-    end
-  end
-
   public
   def prepare_jdbc_connection
     require "sequel"

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.0.4'
+  s.version         = '5.0.5'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -144,7 +144,12 @@ describe LogStash::Inputs::Jdbc do
       {
           "jdbc_user" => 'system',
           "statement" => "SELECT * from test_table",
-          "sequel_opts" => { "convert_types" => false, "jdbc_properties" => { "foo" => 'bar' } }
+          "sequel_opts" => {
+              "truthy" => 'true',
+              "falsey" => 'false',
+              "foo" => 'bar',
+              "jdbc_properties" => { "some" => 'true' }
+          }
       }
     end
 
@@ -158,7 +163,7 @@ describe LogStash::Inputs::Jdbc do
 
     it "should symbolize keys" do
       expect( Sequel ).to receive(:connect).with connection_string,
-                                                 hash_including(:convert_types => false, :jdbc_properties => { 'foo' => 'bar' })
+          hash_including(:truthy => true, :falsey => false, :foo => 'bar', :jdbc_properties => { 'some' => 'true' })
       plugin.send(:jdbc_connect)
     end
   end


### PR DESCRIPTION
in case of the **jdbc input** `sequel_opts => ...` were being passed with string keys (the streaming plugin symbolizes keys).
this is fine e.g. for passing `sequel_opts => { "jdbc_properties" => { ... } }` as sequel handles the `"jdbc_properties"` case but officially it's documented as `:jdbc_properties`. 

string keys turned out problematic when trying to disable quoting using: `sequel_opts => { quote_identifiers => false }` the option wasn't being picked from the Hash, as Sequel only checks for `:quote_identifiers` key.

also took this opportunity to introduce some sharing between jdbc and jdbc_streaming plugins as I noticed some of the previously fixed issues (e.g. driver loading) could also affect the (lesser used) jdbc_streaming plugin.