### PR TITLE
Doc:Replace plugin_header file with plugin_header-integration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.6
+  - DOC:Replaced plugin_header file with plugin_header-integration file. [#40](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/40)
+
 ## 5.0.5
   - Fixed user sequel_opts not being passed down properly [#37](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/37)
   - Refactored jdbc_streaming to share driver loading, so the fixes from the jdbc plugin also effect jdbc_streaming

--- a/docs/filter-jdbc_static.asciidoc
+++ b/docs/filter-jdbc_static.asciidoc
@@ -1,3 +1,4 @@
+:integration: jdbc
 :plugin: jdbc_static
 :type: filter
 

--- a/docs/filter-jdbc_static.asciidoc
+++ b/docs/filter-jdbc_static.asciidoc
@@ -16,7 +16,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Jdbc_static filter plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/filter-jdbc_streaming.asciidoc
+++ b/docs/filter-jdbc_streaming.asciidoc
@@ -1,3 +1,4 @@
+:integration: jdbc
 :plugin: jdbc_streaming
 :type: filter
 

--- a/docs/filter-jdbc_streaming.asciidoc
+++ b/docs/filter-jdbc_streaming.asciidoc
@@ -16,7 +16,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Jdbc_streaming filter plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -1,3 +1,4 @@
+:integration: jdbc
 :plugin: jdbc
 :type: input
 :default_codec: plain

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -17,7 +17,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Jdbc input plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.0.5'
+  s.version         = '5.0.6'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Integration plugins need a header that is different from the stand-alone plugin
header. The plugin docs links should point to the integration repo rather than the
stand-alone plugin repos. The header also adds a note that the plugin is part of
an integration rather than stand-alone.

The new header included in this work was added with elastic/logstash#11891 and elastic/logstash#12163 for the Logstash Reference, and elastic/logstash-docs#891 for the Versioned Plugin Reference.
