### PR TITLE
Add `target` option to jdbc input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.1.0
+  - Added `target` option to JDBC input, allowing the row columns to target a specific field instead of being expanded 
+    at the root of the event. This allows the input to play nicer with the Elastic Common Schema when 
+    the input does not follow the schema. [#69](https://github.com/logstash-plugins/logstash-integration-jdbc/issues/69)
+
 ## 5.0.7
   - Feat: try hard to log Java cause (chain) [#62](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/62)
 

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -211,6 +211,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-sql_log_level>> |<<string,string>>, one of `["fatal", "error", "warn", "info", "debug"]`|No
 | <<plugins-{type}s-{plugin}-statement>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-statement_filepath>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-target>> | {logstash-ref}/field-references-deepdive.html[field reference] | No
 | <<plugins-{type}s-{plugin}-tracking_column>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-tracking_column_type>> |<<string,string>>, one of `["numeric", "timestamp"]`|No
 | <<plugins-{type}s-{plugin}-use_column_value>> |<<boolean,boolean>>|No
@@ -534,6 +535,17 @@ with the `parameters` setting.
   * There is no default value for this setting.
 
 Path of file containing statement to execute
+
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+* Value type is {logstash-ref}/field-references-deepdive.html[field reference]
+* There is no default value for this setting.
+
+Without a `target`, events are created from each row column at the root level.
+When the `target` is set to a field reference, the column of each row is placed in the target field instead.
+
+This option can be useful to avoid populating unknown fields when a downstream schema such as ECS is enforced.
 
 [id="plugins-{type}s-{plugin}-tracking_column"]
 ===== `tracking_column`

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -221,7 +221,6 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
   public
 
   def register
-    puts "register invoked"
     @logger = self.logger
     require "rufus/scheduler"
     prepare_jdbc_connection
@@ -271,7 +270,6 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
 
     # target must be populated if ecs_compatibility is not :disabled
     if @target.nil? && ecs_compatibility != :disabled
-      puts "@target is nil and ecs_compatibility: #{ecs_compatibility}"
       logger.warn("When ECS compatibility is enabled also target option must be valued")
     end
   end # def register

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -4,6 +4,7 @@ require "logstash/namespace"
 require "logstash/plugin_mixins/jdbc/common"
 require "logstash/plugin_mixins/jdbc/jdbc"
 require "logstash/plugin_mixins/ecs_compatibility_support"
+require "logstash/plugin_mixins/validator_support/field_reference_validation_adapter"
 
 # this require_relative returns early unless the JRuby version is between 9.2.0.0 and 9.2.8.0
 require_relative "tzinfo_jruby_patch"
@@ -132,6 +133,8 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
   include LogStash::PluginMixins::Jdbc::Jdbc
   # adds ecs_compatibility config which could be :disabled or :v1
   include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled,:v1)
+  # adds :field_reference validator adapter
+  extend LogStash::PluginMixins::ValidatorSupport::FieldReferenceValidationAdapter
 
   config_name "jdbc"
 

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -274,7 +274,7 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
     # target must be populated if ecs_compatibility is not :disabled
     if @target.nil? && ecs_compatibility != :disabled
       logger.info('ECS compatibility is enabled but no ``target`` option was specified, it is recommended'\
-                  ' to set the option to avoid potential schema conflicts (if you\'re data is ECS compliant or'\
+                  ' to set the option to avoid potential schema conflicts (if your data is ECS compliant or'\
                   ' non-conflicting feel free to ignore this message)')
     end
   end # def register

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -132,7 +132,7 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
   include LogStash::PluginMixins::Jdbc::Common
   include LogStash::PluginMixins::Jdbc::Jdbc
   # adds ecs_compatibility config which could be :disabled or :v1
-  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled,:v1)
+  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled,:v1,:v8 => :v1)
   # adds :field_reference validator adapter
   extend LogStash::PluginMixins::ValidatorSupport::FieldReferenceValidationAdapter
 

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -273,7 +273,9 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
 
     # target must be populated if ecs_compatibility is not :disabled
     if @target.nil? && ecs_compatibility != :disabled
-      logger.warn("When ECS compatibility is enabled also target option must be valued")
+      logger.info('ECS compatibility is enabled but no ``target`` option was specified, it is recommended'\
+                  ' to set the option to avoid potential schema conflicts (if you\'re data is ECS compliant or'\
+                  ' non-conflicting feel free to ignore this message)')
     end
   end # def register
 

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -214,7 +214,7 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
   config :prepared_statement_bind_values, :validate => :array, :default => []
 
   # Define the target field to store the loaded columns
-  config :target, :validate => :string, :required => false
+  config :target, :validate => :field_reference, :required => false
 
   attr_reader :database # for test mocking/stubbing
 

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -209,6 +209,9 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
 
   config :prepared_statement_bind_values, :validate => :array, :default => []
 
+  # Define the target field to store the loaded columns
+  config :target, :validate => :string, :required => false
+
   attr_reader :database # for test mocking/stubbing
 
   public
@@ -318,7 +321,12 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
         ## do the necessary conversions to string elements
         row = Hash[row.map { |k, v| [k.to_s, convert(k, v)] }]
       end
-      event = LogStash::Event.new(row)
+      if @target
+        event = LogStash::Event.new
+        event.set(@target, row)
+      else
+        event = LogStash::Event.new(row)
+      end
       decorate(event)
       queue << event
     end

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'tzinfo-data'
   # 3.5 limitation is required for jdbc-static loading schedule
   s.add_runtime_dependency 'rufus-scheduler', '< 3.5'
-  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.1'
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.2'
   s.add_runtime_dependency "logstash-mixin-validator_support", '~> 1.0'
 
   s.add_development_dependency "childprocess"

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'tzinfo-data'
   # 3.5 limitation is required for jdbc-static loading schedule
   s.add_runtime_dependency 'rufus-scheduler', '< 3.5'
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.1'
 
   s.add_development_dependency "childprocess"
   s.add_development_dependency 'logstash-devutils'

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.0.7'
+  s.version         = '5.1.0'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   # 3.5 limitation is required for jdbc-static loading schedule
   s.add_runtime_dependency 'rufus-scheduler', '< 3.5'
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.1'
+  s.add_runtime_dependency "logstash-mixin-validator_support", '~> 1.0'
 
   s.add_development_dependency "childprocess"
   s.add_development_dependency 'logstash-devutils'

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -364,7 +364,9 @@ describe LogStash::Inputs::Jdbc do
     end
 
     it "should log a warn of missed target usage" do
-      expect(plugin.logger).to receive(:warn).once.with("When ECS compatibility is enabled also target option must be valued")
+      expect(plugin.logger).to receive(:info).once.with('ECS compatibility is enabled but no ``target``'\
+            ' option was specified, it is recommended to set the option to avoid potential schema conflicts' \
+            ' (if you\'re data is ECS compliant or non-conflicting feel free to ignore this message)')
 
       plugin.register
     end

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -365,8 +365,6 @@ describe LogStash::Inputs::Jdbc do
 
     it "should log a warn of missed target usage" do
       expect(plugin.logger).to receive(:info).once.with(/ECS compatibility is enabled but no .*?target.*? was specified/)
-            ' option was specified, it is recommended to set the option to avoid potential schema conflicts' \
-            ' (if you\'re data is ECS compliant or non-conflicting feel free to ignore this message)')
 
       plugin.register
     end

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -364,7 +364,7 @@ describe LogStash::Inputs::Jdbc do
     end
 
     it "should log a warn of missed target usage" do
-      expect(plugin.logger).to receive(:info).once.with('ECS compatibility is enabled but no ``target``'\
+      expect(plugin.logger).to receive(:info).once.with(/ECS compatibility is enabled but no .*?target.*? was specified/)
             ' option was specified, it is recommended to set the option to avoid potential schema conflicts' \
             ' (if you\'re data is ECS compliant or non-conflicting feel free to ignore this message)')
 

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -328,6 +328,33 @@ describe LogStash::Inputs::Jdbc do
 
   end
 
+  context "when using target option" do
+    let(:settings) do
+      {
+        "statement" => "SELECT * from test_table FETCH FIRST 1 ROWS ONLY",
+        "target" => "sub_field"
+      }
+    end
+
+    before do
+      plugin.register
+    end
+
+    after do
+      plugin.stop
+    end
+
+    it "should put all  columns under sub-field" do
+      db[:test_table].insert(:num => 1, :custom_time => Time.now.utc, :created_at => Time.now.utc, :string => "Test target option")
+
+      plugin.run(queue)
+
+      expect(queue.size).to eq(1)
+      event = queue.pop
+      expect(event.get("[sub_field][string]")).to eq("Test target option")
+    end
+  end
+
   context "when fetching time data" do
 
     let(:settings) do

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -344,7 +344,7 @@ describe LogStash::Inputs::Jdbc do
       plugin.stop
     end
 
-    it "should put all  columns under sub-field" do
+    it "should put all columns under sub-field" do
       db[:test_table].insert(:num => 1, :custom_time => Time.now.utc, :created_at => Time.now.utc, :string => "Test target option")
 
       plugin.run(queue)
@@ -352,6 +352,21 @@ describe LogStash::Inputs::Jdbc do
       expect(queue.size).to eq(1)
       event = queue.pop
       expect(event.get("[sub_field][string]")).to eq("Test target option")
+    end
+  end
+
+  context "when using target option is not set and ecs_compatibility is enabled" do
+    let(:settings) do
+      {
+        "statement" => "SELECT * from test_table FETCH FIRST 1 ROWS ONLY",
+        "ecs_compatibility" => :v1
+      }
+    end
+
+    it "should log a warn of missed target usage" do
+      expect(plugin.logger).to receive(:warn).once.with("When ECS compatibility is enabled also target option must be valued")
+
+      plugin.register
     end
   end
 

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -399,38 +399,6 @@ describe LogStash::Inputs::Jdbc do
     end
   end
 
-  context "when fetching row and target option is used" do
-
-      let(:settings) do
-        {
-          "statement" => "SELECT * from test_table",
-          "target" => "target_field",
-        }
-      end
-
-      let(:num_rows) { 10 }
-
-      before do
-        num_rows.times do
-          db[:test_table].insert(:num => 1, :custom_time => Time.now.utc, :created_at => Time.now.utc, :string => "Hello")
-        end
-
-        plugin.register
-      end
-
-      after do
-        plugin.stop
-      end
-
-      it "should nest the loaded columns in target field " do
-        plugin.run(queue)
-        event = queue.pop
-
-        expect(event.get("[target_field][custom_time]")).to be_a(LogStash::Timestamp)
-        expect(event.get("[target_field][string]")).to eq("Hello")
-      end
-    end
-
   describe "when jdbc_default_timezone is set" do
     let(:mixin_settings) do
       { "jdbc_user" => ENV['USER'], "jdbc_driver_class" => "org.apache.derby.jdbc.EmbeddedDriver",


### PR DESCRIPTION
This PR adds the `target` option to configure destination field inside the event to the JDBC input.
When ECS is enabled and the `target` is not specified it log a warn message.

Related #19 