### PR TITLE
Ensure `target` option is defined in Lookups when ECS is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
   - Added `target` option to JDBC input, allowing the row columns to target a specific field instead of being expanded 
     at the root of the event. This allows the input to play nicer with the Elastic Common Schema when 
     the input does not follow the schema. [#69](https://github.com/logstash-plugins/logstash-integration-jdbc/issues/69)
+    
+  - Added `target` to JDBC filter static `local_lookups` to verify it's properly valued when ECS is enabled. 
+    [#71](https://github.com/logstash-plugins/logstash-integration-jdbc/issues/71)
 
 ## 5.0.7
   - Feat: try hard to log Java cause (chain) [#62](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/62)

--- a/lib/logstash/filters/jdbc/lookup.rb
+++ b/lib/logstash/filters/jdbc/lookup.rb
@@ -56,6 +56,10 @@ module LogStash module Filters module Jdbc
       @target = options["target"]
       @id_used_as_target = @target.nil?
       if @id_used_as_target
+        # target shouldn't be nil if ecs_compatibility is not :disabled
+        if globals[:ecs_compatibility] != :disabled
+          logger.info("When ECS compatibility is enabled also target option must be valued")
+        end
         @target = @id
       end
       @options = options

--- a/lib/logstash/filters/jdbc/lookup.rb
+++ b/lib/logstash/filters/jdbc/lookup.rb
@@ -58,7 +58,9 @@ module LogStash module Filters module Jdbc
       if @id_used_as_target
         # target shouldn't be nil if ecs_compatibility is not :disabled
         if globals[:ecs_compatibility] != :disabled
-          logger.info("When ECS compatibility is enabled also target option must be valued")
+          logger.info('ECS compatibility is enabled but no ``target`` option was specified, it is recommended'\
+                            ' to set the option to avoid potential schema conflicts (if your data is ECS compliant or'\
+                            ' non-conflicting feel free to ignore this message)')
         end
         @target = @id
       end

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -218,7 +218,7 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
     options["lookup_jdbc_driver_class"] = @lookup_jdbc_driver_class
     options["lookup_jdbc_driver_library"] = @lookup_jdbc_driver_library
     options["lookup_jdbc_connection_string"] = @lookup_jdbc_connection_string
-    options["ecs_compatibility"] = @ecs_compatibility
+    options["ecs_compatibility"] = ecs_compatibility
     options
   end
 

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -16,7 +16,7 @@ require_relative "jdbc/lookup_processor"
 #
 module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
   # adds ecs_compatibility config which could be :disabled or :v1
-  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1)
+  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)
 
   config_name "jdbc_static"
 

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -2,6 +2,7 @@
 require "logstash-integration-jdbc_jars"
 require "logstash/filters/base"
 require "logstash/namespace"
+require "logstash/plugin_mixins/ecs_compatibility_support"
 require_relative "jdbc/loader"
 require_relative "jdbc/loader_schedule"
 require_relative "jdbc/repeating_load_runner"
@@ -14,6 +15,9 @@ require_relative "jdbc/lookup_processor"
 
 #
 module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
+  # adds ecs_compatibility config which could be :disabled or :v1
+  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1)
+
   config_name "jdbc_static"
 
   # Define the loaders, an Array of Hashes, to fetch remote data and create local tables.
@@ -214,6 +218,7 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
     options["lookup_jdbc_driver_class"] = @lookup_jdbc_driver_class
     options["lookup_jdbc_driver_library"] = @lookup_jdbc_driver_library
     options["lookup_jdbc_connection_string"] = @lookup_jdbc_connection_string
+    options["ecs_compatibility"] = @ecs_compatibility
     options
   end
 

--- a/spec/filters/jdbc/lookup_spec.rb
+++ b/spec/filters/jdbc/lookup_spec.rb
@@ -248,6 +248,37 @@ module LogStash module Filters module Jdbc
         expect(subject.valid?).to be_falsey
       end
     end
+
+    describe "validation of target option" do
+      let(:lookup_hash) do
+        {
+          "query" => "select * from servers WHERE ip LIKE ? AND os LIKE ?",
+          "prepared_parameters" => ["%%{[ip]}"],
+        }
+      end
+
+      it "should log a warn when ECS is enabled and target not defined" do
+
+        class LoggableLookup < Lookup
+
+          @@TEST_LOGGER = nil
+
+          def self.logger=(log)
+            @@TEST_LOGGER = log
+          end
+
+          def self.logger
+            @@TEST_LOGGER
+          end
+        end
+
+        spy_logger = double("logger")
+        expect(spy_logger).to receive(:info).once.with("When ECS compatibility is enabled also target option must be valued")
+        LoggableLookup.logger = spy_logger
+
+        LoggableLookup.new(lookup_hash, {:ecs_compatibility => 'v1'}, "lookup-1")
+      end
+    end
   end
 end end end
 

--- a/spec/filters/jdbc/lookup_spec.rb
+++ b/spec/filters/jdbc/lookup_spec.rb
@@ -273,7 +273,7 @@ module LogStash module Filters module Jdbc
         end
 
         spy_logger = double("logger")
-        expect(spy_logger).to receive(:info).once.with("When ECS compatibility is enabled also target option must be valued")
+        expect(spy_logger).to receive(:info).once.with(/ECS compatibility is enabled but no .*?target.*? was specified/)
         LoggableLookup.logger = spy_logger
 
         LoggableLookup.new(lookup_hash, {:ecs_compatibility => 'v1'}, "lookup-1")


### PR DESCRIPTION
This PR add the validation of `target` sub-option in the blocks of `local_lookups` for `logstash-filter-jdbc_static`.

The `target` attribute already existed, in this case it's only added a check that it's valued in case ECS is enabled.

Related to PR #69
Related to issue #19