### PR TITLE
Add extra safety to local data retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.1.3
-  - Make `jdbc_static` `lookup` more robust when handling errors from `sequel` library[#78](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/78)
+  - Improve robustness when handling errors from `sequel` library in jdbc static and streaming
+    filters[#78](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/78)
 
 ## 5.1.2
   -  Fix `prepared_statement_bind_values` in streaming filter to resolve nested event's fields[#76](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/76)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.3
+  - Make `jdbc_static` `lookup` more robust when handling errors from `sequel` library[#78](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/78)
+
 ## 5.1.2
   -  Fix `prepared_statement_bind_values` in streaming filter to resolve nested event's fields[#76](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/76)
 

--- a/lib/logstash/filters/jdbc/lookup.rb
+++ b/lib/logstash/filters/jdbc/lookup.rb
@@ -162,8 +162,11 @@ module LogStash module Filters module Jdbc
       begin
         logger.debug? && logger.debug("Executing Jdbc query", :lookup_id => @id, :statement => query, :parameters => params)
         proc.call(local, query, params, result)
-      rescue ::Sequel::Error => e
-        # all sequel errors are a subclass of this, let all other standard or runtime errors bubble up
+      rescue => e
+        # In theory all exceptions in Sequel should be wrapped in Sequel::Error
+        # However, there are cases where other errors can occur - a `SQLTransactionRollbackException`
+        # may be thrown during `prepareStatement`. Let's handle these cases here, where we can tag and warn
+        # appropriately rather than bubble up and potentially crash the plugin.
         result.failed!
         logger.warn? && logger.warn("Exception when executing Jdbc query", :lookup_id => @id, :exception => e.message, :backtrace => e.backtrace.take(8))
       end

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -119,8 +119,7 @@ module LogStash  module PluginMixins module Jdbc
           else
             @logger.error("Failed to connect to database. #{@jdbc_pool_timeout} second timeout exceeded. Trying again.")
           end
-        # rescue Java::JavaSql::SQLException, ::Sequel::Error => e
-        rescue ::Sequel::Error => e
+        rescue Java::JavaSql::SQLException, ::Sequel::Error => e
           if retry_attempts <= 0
             log_java_exception(e.cause)
             @logger.error("Unable to connect to database. Tried #{@connection_retry_attempts} times", error_details(e, trace: true))

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.1.2'
+  s.version         = '5.1.3'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Under certain cirumstances, retrieving local data from the embedded derby database
can result in an exception being thrown from the Sequel library that is not wrapped in
a `SequelError`. Prior to this commit, that would result in the exception "escaping" the
plugin, causing the plugin (and the pipeline) to crash.

This commit broadens the scope of the rescue to catch any errors that might result from
that call, enabling the appropriate logging and tagging to take place without crashing
the plugin.

Fixes #77
