### PR TITLE
Static Filter: support multiple positional parameters

### DIFF
--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -163,7 +163,7 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
   def close
     @scheduler.stop if @scheduler
     @parsed_loaders.each(&:close)
-    @processor.close
+    @processor.close if @processor
   end
 
   def loader_runner

--- a/spec/filters/integration/jdbc_static_spec.rb
+++ b/spec/filters/integration/jdbc_static_spec.rb
@@ -156,6 +156,47 @@ module LogStash module Filters
         end
       end
 
+      context "under normal conditions with query with multiple named parameters" do
+
+        let(:event) { LogStash::Event.new("host" => { "ip" => "10.3.1.1", "name" => "mv-server-1"}, "message" => "ping") }
+        let(:lookup_statement) { "SELECT * FROM servers WHERE ip = :host_ip AND name = :host_name" }
+
+        let(:settings) do
+          {
+            "jdbc_user" => ENV['USER'],
+            "jdbc_password" => ENV["POSTGRES_PASSWORD"],
+            "jdbc_driver_class" => "org.postgresql.Driver",
+            "jdbc_driver_library" => "/usr/share/logstash/postgresql.jar",
+            "staging_directory" => temp_import_path_plugin,
+            "jdbc_connection_string" => jdbc_connection_string,
+            "loaders" => [
+              {
+                "id" =>"servers",
+                "query" => loader_statement,
+                "local_table" => "servers"
+              }
+            ],
+            "local_db_objects" => local_db_objects,
+            "local_lookups" => [
+              {
+                "query" => lookup_statement,
+                "parameters" => {
+                  "host_ip" => "[host][ip]",
+                  "host_name" =>"[host][name]"
+                },
+                "target" => "server"
+              }
+            ]
+          }
+        end
+
+        it "enhances an event" do
+          plugin.register
+          plugin.filter(event)
+          expect(event.get("server")).to eq([{"ip"=>"10.3.1.1", "name"=>"mv-server-1", "location"=>"MV-9-6-4"}])
+        end
+      end
+
       context "under normal conditions when index_columns is not specified" do
         let(:local_db_objects) do
           [

--- a/spec/filters/integration/jdbc_static_spec.rb
+++ b/spec/filters/integration/jdbc_static_spec.rb
@@ -118,6 +118,44 @@ module LogStash module Filters
         end
       end
 
+      context "under normal conditions with prepared statement with multiple positional parameters" do
+
+        let(:event) { LogStash::Event.new("host" => { "ip" => "10.3.1.1", "name" => "mv-server-1"}, "message" => "ping") }
+        let(:lookup_statement) { "SELECT * FROM servers WHERE ip = ? AND name = ?" }
+
+        let(:settings) do
+          {
+            "jdbc_user" => ENV['USER'],
+            "jdbc_password" => ENV["POSTGRES_PASSWORD"],
+            "jdbc_driver_class" => "org.postgresql.Driver",
+            "jdbc_driver_library" => "/usr/share/logstash/postgresql.jar",
+            "staging_directory" => temp_import_path_plugin,
+            "jdbc_connection_string" => jdbc_connection_string,
+            "loaders" => [
+              {
+                "id" =>"servers",
+                "query" => loader_statement,
+                "local_table" => "servers"
+              }
+            ],
+            "local_db_objects" => local_db_objects,
+            "local_lookups" => [
+              {
+                "query" => lookup_statement,
+                "prepared_parameters" => ["[host][ip]", "[host][name]"],
+                "target" => "server"
+              }
+            ]
+          }
+        end
+
+        it "enhances an event" do
+          plugin.register
+          plugin.filter(event)
+          expect(event.get("server")).to eq([{"ip"=>"10.3.1.1", "name"=>"mv-server-1", "location"=>"MV-9-6-4"}])
+        end
+      end
+
       context "under normal conditions when index_columns is not specified" do
         let(:local_db_objects) do
           [


### PR DESCRIPTION
When multiple `prepared_parameters` are passed to the local lookup, the Sequel library raises an exception with `Mismatched number of placeholders` even when the provided query has the correct number of placeholders. Our unit specs stub out the prepared statement details and therefore do not show off the issue.

_There is a workaround listed at the end of this Issue._

This PR introduces a failing spec showing the behaviour when
 -  the local lookup is configured with:
    - `query => "SELECT * FROM servers WHERE ip = ? AND name = ?"`
    - `prepared_parameters => ["[host][ip]", "[host][name]"]`
 - using an event with the structure:
    - `"host" : { "ip" : "10.3.1.1", "name" : "mv-server-1"}, "message" : "ping"}`

> ~~~
> Failures:
> 
>   1) LogStash::Filters::JdbcStatic non scheduled operation under normal conditions with prepared statement with multiple positional parameters enhances an event
>      Failure/Error: @db[statement, parameters].prepare(:select, @id)
> 
>      Sequel::Error:
>        Mismatched number of placeholders (2) and placeholder arguments (1) when using placeholder string
>      # ./lib/logstash/filters/jdbc/read_write_database.rb:32:in `prepare'
>      # ./lib/logstash/filters/jdbc/lookup.rb:117:in `prepare'
>      # ./lib/logstash/filters/jdbc/lookup_processor.rb:68:in `block in create_prepared_statements_for_lookups'
>      # ./lib/logstash/filters/jdbc/lookup_processor.rb:66:in `create_prepared_statements_for_lookups'
>      # ./lib/logstash/filters/jdbc/lookup_processor.rb:42:in `initialize'
>      # ./lib/logstash/filters/jdbc_static.rb:191:in `prepare_runner'
>      # ./lib/logstash/filters/jdbc_static.rb:155:in `register'
>      # ./spec/filters/integration/jdbc_static_spec.rb:153:in `block in Filters'
> 
> Finished in 9.43 seconds (files took 9.28 seconds to load)
> 18 examples, 1 failure
> 
> Failed examples:
> 
> rspec ./spec/filters/integration/jdbc_static_spec.rb:152 # LogStash::Filters::JdbcStatic non scheduled operation under normal conditions with prepared statement with multiple positional parameters enhances an event
> ~~~

# Workaround

Instead of using prepared statements and `positional_parameters`, it is safe to use a regular query with named placeholders and the `parameters` option, as demonstrated by a companion integration spec in this PR:

 -  the local lookup is configured with:
    - `query => "SELECT * FROM servers WHERE ip = :host_ip AND name = :host_name"`
    - `prepared_parameters => {"host_ip" => "[host][ip]" "host_name" => "[host][name]" }`
 - using an event with the same structure as before:
    - `"host" : { "ip" : "10.3.1.1", "name" : "mv-server-1"}, "message" : "ping"}`