### PR TITLE
Serialize the loading of drivers, avoiding concurrent load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.6
+  - Fix, serialize the JDBC driver loading steps to avoid concurrency issues [#84](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/84)
+
 ## 5.1.5
   - Refined ECS support [#82](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/82)
     - Uses shared `target` guidance when ECS compatibility is enabled

--- a/lib/logstash/plugin_mixins/jdbc/common.rb
+++ b/lib/logstash/plugin_mixins/jdbc/common.rb
@@ -4,6 +4,8 @@ module LogStash module PluginMixins module Jdbc
 
     private
 
+    DRIVERS_LOADING_LOCK = java.util.concurrent.locks.ReentrantLock.new()
+
     def complete_sequel_opts(defaults = {})
       sequel_opts = @sequel_opts.
           map { |key,val| [key.is_a?(String) ? key.to_sym : key, val] }.
@@ -22,18 +24,24 @@ module LogStash module PluginMixins module Jdbc
       require "sequel"
       require "sequel/adapters/jdbc"
 
-      load_driver_jars
+      DRIVERS_LOADING_LOCK.lock()
+
       begin
-        @driver_impl = Sequel::JDBC.load_driver(@jdbc_driver_class)
-      rescue Sequel::AdapterNotFound => e # Sequel::AdapterNotFound, "#{@jdbc_driver_class} not loaded"
-        # fix this !!!
-        message = if jdbc_driver_library_set?
-                    "Are you sure you've included the correct jdbc driver in :jdbc_driver_library?"
-                  else
-                    ":jdbc_driver_library is not set, are you sure you included " +
-                        "the proper driver client libraries in your classpath?"
-                  end
-        raise LogStash::PluginLoadingError, "#{e}. #{message}"
+        load_driver_jars
+        begin
+          @driver_impl = Sequel::JDBC.load_driver(@jdbc_driver_class)
+        rescue Sequel::AdapterNotFound => e # Sequel::AdapterNotFound, "#{@jdbc_driver_class} not loaded"
+          # fix this !!!
+          message = if jdbc_driver_library_set?
+                      "Are you sure you've included the correct jdbc driver in :jdbc_driver_library?"
+                    else
+                      ":jdbc_driver_library is not set, are you sure you included " +
+                          "the proper driver client libraries in your classpath?"
+                    end
+          raise LogStash::PluginLoadingError, "#{e}. #{message} #{e.backtrace}"
+        end
+      ensure
+        DRIVERS_LOADING_LOCK.unlock()
       end
     end
 

--- a/lib/logstash/plugin_mixins/jdbc/common.rb
+++ b/lib/logstash/plugin_mixins/jdbc/common.rb
@@ -24,8 +24,9 @@ module LogStash module PluginMixins module Jdbc
       require "sequel"
       require "sequel/adapters/jdbc"
 
+      # execute all the driver loading related duties in a serial fashion to avoid
+      # concurrency related problems with multiple pipelines and multiple drivers
       DRIVERS_LOADING_LOCK.lock()
-
       begin
         load_driver_jars
         begin

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.1.5'
+  s.version         = '5.1.6'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Serialize access to JDBC driver loading

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
This commit use a lock to serialize the loading steps of a JDBC driver, avoiding concurrency related problem during load.


## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
When the user has different pipelines with different JDBC plugins that uses different drivers, and one of this is SyBase, sometime could manifest the issue #83

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Clone this branch locally and in a LS installation's `Gemfile` add the 
```
gem "logstash-integration-jdbc", :path => "/path_to/logstash_plugins/logstash-integration-jdbc"
```
Install it with ```bin/logstash-plugin install --no-verify```  and follow the `Steps to reproduce` section in issue #83

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- closes #83 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
