### PR TITLE
ci: format specs as documentation to make CI runs readable

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format=documentation


### PR DESCRIPTION
When run in CI, this project's custom `.ci/run.sh` script supplies no _format_ directive to rspec so the CI output is "progress", or one dot (`.`) per spec succeeded and one capital f (`F`) per spec failed.

By supplying an `.rspec` config, we can ensure that CI output is our readable specification.