### PR TITLE
Fix explanation of cache_expiration option

### DIFF
--- a/docs/filter-jdbc_streaming.asciidoc
+++ b/docs/filter-jdbc_streaming.asciidoc
@@ -126,7 +126,7 @@ filter plugins.
   * Value type is <<number,number>>
   * Default value is `5.0`
 
-The minimum number of seconds any entry should remain in the cache. Defaults to 5 seconds.
+The maximum number of seconds any entry should remain in the cache. Defaults to 5 seconds.
 
 A numeric value. You can use decimals for example: `cache_expiration => 0.25`.
 If there are transient jdbc errors, the cache will store empty results for a


### PR DESCRIPTION
Copy of https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/pull/24

The cache_expiration option sets the "ttl" parameter of the cache:
https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/blob/master/lib/logstash/filters/jdbc_streaming.rb#L54
From the moment an entry is added to the cache, it can only be used until it reaches the TTL. After that a read will re-fetch it from the database.

<!--
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
-->