### PR TITLE
Ambiguous Timestamp Handling

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -5,4 +5,4 @@ set -ex
 
 export USER='logstash'
 
-bundle exec rspec spec && bundle exec rspec spec --tag integration
+bundle exec rspec spec --format documentation && bundle exec rspec spec --format documentation --tag integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.0
+  - Added support for disambiguating timestamps in daylight-savings overlap periods
+
 ## 5.1.8
   - Fix the blocking pipeline reload and shutdown when connectivity issues happen [#85](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/85)
 

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -282,6 +282,8 @@ JDBC connection string
 ===== `jdbc_default_timezone`
 
   * Value type is <<string,string>>
+  ** Value should be a canonical timezone or offset, such as `Europe/Paris` or `Etc/GMT+3`
+  ** Value _may_ include square-bracketed extensions, such as `America/Denver[dst_enabled_on_overlap:true]`
   * There is no default value for this setting.
 
 Timezone conversion.
@@ -295,7 +297,12 @@ in relative UTC time in ISO8601 format.
 
 Using this setting will manually assign a specified timezone offset, instead
 of using the timezone setting of the local machine.  You must use a canonical
-timezone, *America/Denver*, for example.
+timezone, `America/Denver`, for example.
+
+Ambiguous Timestamps.
+While it is common to store local times in SQL's timestamp column type, many timezones change their offset during the course of a calendar year and therefore cannot be used with SQL's timestamp type to represent an ordered, continuous timeline.
+For example in the `America/Chicago` zone when daylight savings ends in the autumn, the clock rolls from `01:59:59` back to `01:00:00`, making any timestamp in the 2-hour period between `01:00:00CDT` and `02:00:00CST` on that day ambiguous.
+When encountering an ambiguous timestamp caused by a DST transition, the query will fail unless the timezone specified here includes a square-bracketed instruction for how to handle overlapping periods (such as: `America/Chicago[dst_enabled_on_overlap:true]` or `Australia/Melbourne[dst_enabled_on_overlap:false]`).
 
 [id="plugins-{type}s-{plugin}-plugin_timezone"]
 ===== `plugin_timezone`

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -4,6 +4,7 @@ require "logstash/config/mixin"
 require "time"
 require "date"
 require_relative "value_tracking"
+require_relative "timezone_proxy"
 require_relative "checked_count_logger"
 require_relative "statement_handler"
 
@@ -155,7 +156,7 @@ module LogStash  module PluginMixins module Jdbc
       @database.extension(:pagination)
       if @jdbc_default_timezone
         @database.extension(:named_timezones)
-        @database.timezone = @jdbc_default_timezone
+        @database.timezone = TimezoneProxy.parse(@jdbc_default_timezone)
       end
       if @jdbc_validate_connection
         @database.extension(:connection_validator)

--- a/lib/logstash/plugin_mixins/jdbc/timezone_proxy.rb
+++ b/lib/logstash/plugin_mixins/jdbc/timezone_proxy.rb
@@ -1,0 +1,44 @@
+# encoding: utf-8
+
+require 'tzinfo'
+
+module LogStash module PluginMixins module Jdbc
+  class TimezoneProxy < SimpleDelegator
+    ##
+    # Wraps a ruby timezone object in an object that has an explicit preference in time conversions
+    # either for or against having DST enabled.
+    #
+    # @param timezone [String,TZInfo::Timezone]
+    # @param dst_enabled_on_overlap [Boolean] (default: nil) when encountering an ambiguous time,
+    # declare a preference for selecting the option with DST either enabled or disabled.
+    def self.wrap(timezone, dst_enabled_on_overlap)
+      timezone = ::TZInfo::Timezone.get(timezone) if timezone.kind_of?(String)
+      dst_enabled_on_overlap.nil? ? timezone : new(timezone, dst_enabled_on_overlap)
+    end
+
+    def self.parse(timezone_spec)
+      md = /\A(?<base_spec>[^\[]+)(\[prefer-dst:(?<prefer_dst_spec>true|false)\])?\z/.match(timezone_spec)
+
+      timezone = TZInfo::Timezone.get(md[:base_spec])
+      return timezone unless md[:prefer_dst_spec]
+
+      wrap(timezone, md[:prefer_dst_spec] == 'true')
+    end
+
+    ##
+    # @api private
+    def initialize(timezone, dst_enabled_on_overlap)
+      super(timezone) # SimpleDelegator
+      @dst_enabled_on_overlap = dst_enabled_on_overlap
+    end
+
+    ##
+    # @override `Timezone#period_for_local`
+    # inject an implicit preference for DST being either enabled or disabled if called
+    # without an explicit preference
+    def period_for_local(value, dst_enabled_on_overlap=nil, &global_disambiguator)
+      dst_enabled_on_overlap = @dst_enabled_on_overlap if dst_enabled_on_overlap.nil?
+      __getobj__.period_for_local(value, dst_enabled_on_overlap, &global_disambiguator)
+    end
+  end
+end; end; end

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.1.8'
+  s.version         = '5.2.0'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1468,7 +1468,7 @@ describe LogStash::Inputs::Jdbc do
     end
 
     context "when initialized with a preference for DST being enabled" do
-      let(:jdbc_default_timezone) { 'America/Chicago[prefer-dst:true]' }
+      let(:jdbc_default_timezone) { 'America/Chicago[dst_enabled_on_overlap:true]' }
 
       it 'treats the timestamp column as if DST was enabled' do
         plugin.run(queue)
@@ -1477,7 +1477,7 @@ describe LogStash::Inputs::Jdbc do
       end
     end
     context "when initialized with a preference for DST being disabled" do
-      let(:jdbc_default_timezone) { 'America/Chicago[prefer-dst:false]' }
+      let(:jdbc_default_timezone) { 'America/Chicago[dst_enabled_on_overlap:false]' }
 
       it 'treats the timestamp column as if DST was disabled' do
         plugin.run(queue)

--- a/spec/plugin_mixins/jdbc/timezone_proxy_spec.rb
+++ b/spec/plugin_mixins/jdbc/timezone_proxy_spec.rb
@@ -1,0 +1,46 @@
+# encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/plugin_mixins/jdbc/timezone_proxy"
+
+describe LogStash::PluginMixins::Jdbc::TimezoneProxy do
+  subject(:timezone) { described_class.parse(timezone_spec) }
+
+  context 'when handling a daylight-savings ambiguous time' do
+    context 'without extensions' do
+      let(:timezone_spec) { 'America/Los_Angeles[]' }
+      it 'raises an AmbiguousTime error' do
+        expect { timezone.local_time(2021,11,7,1,17) }.to raise_error(TZInfo::AmbiguousTime)
+      end
+    end
+    context 'with extension `dst_enabled_on_overlap:true`' do
+      let(:timezone_spec) { 'America/Los_Angeles[dst_enabled_on_overlap:true]' }
+      it 'resolves as if DST were enabled' do
+        timestamp = timezone.local_time(2021,11,7,1,17)
+        aggregate_failures do
+          expect(timestamp.dst?).to be true
+          expect(timestamp.zone).to eq('PDT') # Pacific Daylight Time
+          expect(timestamp.getutc).to eq(Time.utc(2021,11,7,8,17))
+          expect(timestamp.utc_offset).to eq( -7 * 3600 )
+        end
+      end
+      end
+    context 'with extension `dst_enabled_on_overlap:false`' do
+      let(:timezone_spec) { 'America/Los_Angeles[dst_enabled_on_overlap:false]' }
+      it 'resolves as if DST were disabled' do
+        timestamp = timezone.local_time(2021,11,7,1,17)
+        aggregate_failures do
+          expect(timestamp.dst?).to be false
+          expect(timestamp.zone).to eq('PST') # Pacific Standard Time
+          expect(timestamp.getutc).to eq(Time.utc(2021,11,7,9,17))
+          expect(timestamp.utc_offset).to eq( -8 * 3600 )
+        end
+      end
+    end
+    context 'with invalid extension' do
+      let(:timezone_spec) { 'America/Los_Angeles[dst_enabled_on_overlap:false;nope:wrong]' }
+      it 'raises an exception with a helpful message' do
+        expect { timezone }.to raise_exception(ArgumentError, a_string_including("Invalid timezone extension `nope:wrong`"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds support for timezones provided to `jdbc_default_timezone` to include instructions for how to handle ambiguous times from daylight-savings related overlaps.

The SQL Timestamp column type does not contain offset information, so when it is used to store local times and those local times come from a timezone with seasonal daylight savings transitions, there is the possibility for a timestamp to be ambiguous.

When reading a timestamp from such a column that cannot be unambiguously resolved to a single point on an ordered and continuous timeline, a `TZInfo::AmbiguousTime` has been raised mid-processing, causing a `Sequel::InvalidValue` to be raised and subsequent rows in the result set to not be emitted.

This changeset allows a user to configure DST-related disambiguation when specifying their `jdbc_default_timezone`. When encountering an ambiguous timestamp in the 2 overlapping hours surrounding the transition from Daylight Savings time to Standard Time:

 - `jdbc_default_timezone => "America/Los_Angeles[dst_enabled_on_overlap:true]"`: ambiguous timestamps is assumed to be from _before_ the transition point
 - `jdbc_default_timezone => "America/Los_Angeles[dst_enabled_on_overlap:false]"`: ambiguous timestamps is assumed to be from _after_ the transition point
 - `jdbc_default_timezone => "America/Los_Angeles"`: ambiguous timestamps results in query failure