### PR TITLE
Add another flexible way for JDBC paging (manual mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.2.0
-  - Added `jdbc_paging_manual_mode` option to avoid the initial count query in paginated queries [#90](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/90)
+  - Added `jdbc_paging_manual_mode` option to avoid the initial count query in paginated queries [#95](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/95)
 
 ## 5.1.10
   - Refactor: to explicit Java (driver) class name loading [#96](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/96),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.0
+  - Added `jdbc_paging_manual_mode` option to avoid the initial count query in paginated queries [#90](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/90)
+
 ## 5.1.10
   - Refactor: to explicit Java (driver) class name loading [#96](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/96),
     the change is expected to provide a more robust fix for the driver loading issue [#83](https://github.com/logstash-plugins/logstash-integration-jdbc/issues/83).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.2.0
-  - Added `jdbc_paging_manual_mode` option to avoid the initial count query in paginated queries [#95](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/95)
+  - Added `jdbc_paging_mode` option to choose if use `explicit` pagination in statements and avoid the initial count 
+    query or use `auto` to delegate to the underlying library [#95](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/95)
 
 ## 5.1.10
   - Refactor: to explicit Java (driver) class name loading [#96](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/96),

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -385,12 +385,12 @@ Whether to use count query during the JDBC paging
 If false, a count query followed by multiple paged queries (with `LIMIT` statement, etc.) are used under the hood.
 
 If true, multiple paged queries (without a count query ahead) will be performed until no more rows are retrieved.
-The `offset` and `size` parameters can be used in the statement (`size` equal to `jdbc_page_size`, and `offset` incremented by `size`).
+The `offset` and `size` parameters must be used in your statement (`size` equal to `jdbc_page_size`, and `offset` incremented by `size`).
 Example:
 
 [source, ruby]
 ------------------------------------------------------
-"SELECT id, mycolumn1, mycolumn2 FROM my_table WHERE id > :sql_last_value LIMIT :offset, :size"
+"SELECT id, mycolumn1, mycolumn2 FROM my_table WHERE id > :sql_last_value LIMIT :size OFFSET :offset"
 ------------------------------------------------------
 
 [source, ruby]

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -153,7 +153,7 @@ NOTE: Not all JDBC accessible technologies will support prepared statements.
 With the introduction of Prepared Statement support comes a different code execution path and some new settings. Most of the existing settings are still useful but there are several new settings for Prepared Statements to read up on.
 Use the boolean setting `use_prepared_statements` to enable this execution mode. Use the `prepared_statement_name` setting to specify a name for the Prepared Statement, this identifies the prepared statement locally and remotely and it should be unique in your config and on the database. Use the `prepared_statement_bind_values` array setting to specify the bind values, use the exact string `:sql_last_value` (multiple times if necessary) for the predefined parameter mentioned before. The `statement` (or `statement_path`) setting still holds the SQL statement but to use bind variables you must use the `?` character as a placeholder in the exact order found in the `prepared_statement_bind_values` array.
 
-NOTE: Building count queries around a prepared statement is not supported at this time and because jdbc paging uses count queries (when `jdbc_page_size` is greater than `0`) under the hood, jdbc paging is not supported with prepared statements at this time either. Therefore, `jdbc_paging_enabled`, `jdbc_page_size` settings are ignored when using prepared statements.
+NOTE: Building count queries around a prepared statement is not supported at this time and because jdbc paging uses count queries (when `jdbc_paging_avoid_count` is false) under the hood, jdbc paging is not supported with prepared statements at this time either. Therefore, `jdbc_paging_enabled`, `jdbc_page_size` settings are ignored when using prepared statements.
 
 Example:
 [source,ruby]
@@ -193,6 +193,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-jdbc_fetch_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-jdbc_page_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-jdbc_paging_enabled>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-jdbc_paging_avoid_count>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-jdbc_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-jdbc_password_filepath>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-jdbc_pool_timeout>> |<<number,number>>|No
@@ -359,22 +360,6 @@ JDBC fetch size. if not provided, respective driver's default will be used
 
 JDBC page size
 
-If greater than `0`, a count query and multiple paged queries (with `LIMIT` statement, etc.) are used under the hood.
-
-Otherwise, if less than `0`, multiple queries (without count query) will be performed until no rows are returned.
-The `:offset` and `:size` parameters can be used in the statement (`:size` equal to `-jdbc_page_size`, and `:offset` incremented by `:size`).
-Example:
-
-[source, ruby]
------------------------------------------------
-"SELECT id, mycolumn1, mycolumn2 FROM my_table WHERE id > :sql_last_value LIMIT :offset, :size"
------------------------------------------------
-
-[source, ruby]
------------------------------------------------
-"CALL fetch_my_data(:sql_last_value, :offset, :size)"
------------------------------------------------
-
 [id="plugins-{type}s-{plugin}-jdbc_paging_enabled"]
 ===== `jdbc_paging_enabled`
 
@@ -388,6 +373,30 @@ Each query will use limits and offsets to collectively retrieve the full
 result-set. The limit size is set with `jdbc_page_size`.
 
 Be aware that ordering is not guaranteed between queries.
+
+[id="plugins-{type}s-{plugin}-jdbc_paging_avoid_count"]
+===== `jdbc_paging_avoid_count`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Whether to use count query during the JDBC paging
+
+If false, a count query and multiple paged queries (with `LIMIT` statement, etc.) are used under the hood.
+
+Otherwise, if true, multiple paged queries (without a count query ahead) will be performed until no more rows are retrieved.
+The `offset` and `size` parameters can be used in the statement (`size` equal to `jdbc_page_size`, and `offset` incremented by `size`).
+Example:
+
+[source, ruby]
+------------------------------------------------------
+"SELECT id, mycolumn1, mycolumn2 FROM my_table WHERE id > :sql_last_value LIMIT :offset, :size"
+------------------------------------------------------
+
+[source, ruby]
+------------------------------------------------------
+"CALL fetch_my_data(:sql_last_value, :offset, :size)"
+------------------------------------------------------
 
 [id="plugins-{type}s-{plugin}-jdbc_password"]
 ===== `jdbc_password`

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -153,7 +153,7 @@ NOTE: Not all JDBC accessible technologies will support prepared statements.
 With the introduction of Prepared Statement support comes a different code execution path and some new settings. Most of the existing settings are still useful but there are several new settings for Prepared Statements to read up on.
 Use the boolean setting `use_prepared_statements` to enable this execution mode. Use the `prepared_statement_name` setting to specify a name for the Prepared Statement, this identifies the prepared statement locally and remotely and it should be unique in your config and on the database. Use the `prepared_statement_bind_values` array setting to specify the bind values, use the exact string `:sql_last_value` (multiple times if necessary) for the predefined parameter mentioned before. The `statement` (or `statement_path`) setting still holds the SQL statement but to use bind variables you must use the `?` character as a placeholder in the exact order found in the `prepared_statement_bind_values` array.
 
-NOTE: Building count queries around a prepared statement is not supported at this time and because jdbc paging uses count queries (when `jdbc_paging_avoid_count` is false) under the hood, jdbc paging is not supported with prepared statements at this time either. Therefore, `jdbc_paging_enabled`, `jdbc_page_size` settings are ignored when using prepared statements.
+NOTE: Building count queries around a prepared statement is not supported at this time. Because jdbc paging uses count queries when `jdbc_paging_manual_mode` is false，jdbc paging is not supported with prepared statements at this time either. Therefore, `jdbc_paging_enabled`, `jdbc_page_size` settings are ignored when using prepared statements.
 
 Example:
 [source,ruby]
@@ -193,7 +193,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-jdbc_fetch_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-jdbc_page_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-jdbc_paging_enabled>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-jdbc_paging_avoid_count>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-jdbc_paging_manual_mode>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-jdbc_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-jdbc_password_filepath>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-jdbc_pool_timeout>> |<<number,number>>|No
@@ -374,29 +374,51 @@ result-set. The limit size is set with `jdbc_page_size`.
 
 Be aware that ordering is not guaranteed between queries.
 
-[id="plugins-{type}s-{plugin}-jdbc_paging_avoid_count"]
-===== `jdbc_paging_avoid_count`
+[id="plugins-{type}s-{plugin}-jdbc_paging_manual_mode"]
+===== `jdbc_paging_manual_mode`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-Whether to use count query during the JDBC paging
+Whether to use manual mode during the JDBC paging
 
-If false, a count query followed by multiple paged queries (with `LIMIT` statement, etc.) are used under the hood.
+If false, your statement will be automatically surrounded by a count query and subsequent multiple paged queries (with `LIMIT` statement, etc.).
 
-If true, multiple paged queries (without a count query ahead) will be performed until no more rows are retrieved.
-The `offset` and `size` parameters must be used in your statement (`size` equal to `jdbc_page_size`, and `offset` incremented by `size`).
+If true, multiple queries (without a count query ahead) will be performed with your statement, until no more rows are retrieved.
+You have to write your own paging conditions in your statement configuration.
+The `offset` and `size` parameters can be used in your statement (`size` equal to `jdbc_page_size`, and `offset` incremented by `size` for each query).
+When the number of rows returned by the query is not equal to 'size', SQL paging will be ended.
 Example:
 
 [source, ruby]
 ------------------------------------------------------
-"SELECT id, mycolumn1, mycolumn2 FROM my_table WHERE id > :sql_last_value LIMIT :size OFFSET :offset"
+input {
+  jdbc {
+    statement => "SELECT id, mycolumn1, mycolumn2 FROM my_table WHERE id > :sql_last_value LIMIT :size OFFSET :offset",
+    jdbc_paging_enabled => true,
+    jdbc_paging_manual_mode => true,
+    jdbc_page_size => 100000
+  }
+}
 ------------------------------------------------------
 
 [source, ruby]
 ------------------------------------------------------
-"CALL fetch_my_data(:sql_last_value, :offset, :size)"
+input {
+  jdbc {
+    statement => "CALL fetch_my_data(:sql_last_value, :offset, :size)",
+    jdbc_paging_enabled => true,
+    jdbc_paging_manual_mode => true,
+    jdbc_page_size => 100000
+  }
+}
 ------------------------------------------------------
+
+This mode can be considered in the following situations:
+
+. Performance issues encountered in default paging mode.
+. Your SQL statement is complex, so simply surrounding it with paging statements is not what you want.
+. Your statement is a stored procedure, and the actual paging statement is inside it.
 
 [id="plugins-{type}s-{plugin}-jdbc_password"]
 ===== `jdbc_password`

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -129,6 +129,9 @@ Here is the list:
 |sql_last_value | The value used to calculate which rows to query. Before any query is run,
 this is set to Thursday, 1 January 1970, or 0 if `use_column_value` is true and
 `tracking_column` is set. It is updated accordingly after subsequent queries are run.
+|offset, size| Values used in manual paging mode. Used in queries to explicitly implement
+the paging. Usable only if <<plugins-{type}s-{plugin}-jdbc_paging_enabled>> and
+<<plugins-{type}s-{plugin}-jdbc_paging_manual_mode>>  are enabled.
 |==========================================================
 
 Example:

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -153,7 +153,7 @@ NOTE: Not all JDBC accessible technologies will support prepared statements.
 With the introduction of Prepared Statement support comes a different code execution path and some new settings. Most of the existing settings are still useful but there are several new settings for Prepared Statements to read up on.
 Use the boolean setting `use_prepared_statements` to enable this execution mode. Use the `prepared_statement_name` setting to specify a name for the Prepared Statement, this identifies the prepared statement locally and remotely and it should be unique in your config and on the database. Use the `prepared_statement_bind_values` array setting to specify the bind values, use the exact string `:sql_last_value` (multiple times if necessary) for the predefined parameter mentioned before. The `statement` (or `statement_path`) setting still holds the SQL statement but to use bind variables you must use the `?` character as a placeholder in the exact order found in the `prepared_statement_bind_values` array.
 
-NOTE: Building count queries around a prepared statement is not supported at this time and because jdbc paging uses count queries under the hood, jdbc paging is not supported with prepared statements at this time either. Therefore, `jdbc_paging_enabled`, `jdbc_page_size` settings are ignored when using prepared statements.
+NOTE: Building count queries around a prepared statement is not supported at this time and because jdbc paging uses count queries (when `jdbc_page_size` is greater than `0`) under the hood, jdbc paging is not supported with prepared statements at this time either. Therefore, `jdbc_paging_enabled`, `jdbc_page_size` settings are ignored when using prepared statements.
 
 Example:
 [source,ruby]
@@ -358,6 +358,22 @@ JDBC fetch size. if not provided, respective driver's default will be used
   * Default value is `100000`
 
 JDBC page size
+
+If greater than `0`, a count query and multiple paged queries (with `LIMIT` statement, etc.) are used under the hood.
+
+Otherwise, if less than `0`, multiple queries (without count query) will be performed until no rows are returned.
+The `:offset` and `:size` parameters can be used in the statement (`:size` equal to `-jdbc_page_size`, and `:offset` incremented by `:size`).
+Example:
+
+[source, ruby]
+-----------------------------------------------
+"SELECT id, mycolumn1, mycolumn2 FROM my_table WHERE id > :sql_last_value LIMIT :offset, :size"
+-----------------------------------------------
+
+[source, ruby]
+-----------------------------------------------
+"CALL fetch_my_data(:sql_last_value, :offset, :size)"
+-----------------------------------------------
 
 [id="plugins-{type}s-{plugin}-jdbc_paging_enabled"]
 ===== `jdbc_paging_enabled`

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -382,9 +382,9 @@ Be aware that ordering is not guaranteed between queries.
 
 Whether to use count query during the JDBC paging
 
-If false, a count query and multiple paged queries (with `LIMIT` statement, etc.) are used under the hood.
+If false, a count query followed by multiple paged queries (with `LIMIT` statement, etc.) are used under the hood.
 
-Otherwise, if true, multiple paged queries (without a count query ahead) will be performed until no more rows are retrieved.
+If true, multiple paged queries (without a count query ahead) will be performed until no more rows are retrieved.
 The `offset` and `size` parameters can be used in the statement (`size` equal to `jdbc_page_size`, and `offset` incremented by `size`).
 Example:
 

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -130,7 +130,8 @@ Here is the list:
 this is set to Thursday, 1 January 1970, or 0 if `use_column_value` is true and
 `tracking_column` is set. It is updated accordingly after subsequent queries are run.
 |offset, size| Values used with manual paging mode to explicitly implement the paging.
-Supported only if <<plugins-{type}s-{plugin}-jdbc_paging_enabled>> and <<plugins-{type}s-{plugin}-jdbc_paging_manual_mode>> are enabled.
+Supported only if <<plugins-{type}s-{plugin}-jdbc_paging_enabled>> is enabled and
+<<plugins-{type}s-{plugin}-jdbc_paging_mode>> has the `explicit` value.
 |==========================================================
 
 Example:
@@ -155,7 +156,7 @@ NOTE: Not all JDBC accessible technologies will support prepared statements.
 With the introduction of Prepared Statement support comes a different code execution path and some new settings. Most of the existing settings are still useful but there are several new settings for Prepared Statements to read up on.
 Use the boolean setting `use_prepared_statements` to enable this execution mode. Use the `prepared_statement_name` setting to specify a name for the Prepared Statement, this identifies the prepared statement locally and remotely and it should be unique in your config and on the database. Use the `prepared_statement_bind_values` array setting to specify the bind values, use the exact string `:sql_last_value` (multiple times if necessary) for the predefined parameter mentioned before. The `statement` (or `statement_path`) setting still holds the SQL statement but to use bind variables you must use the `?` character as a placeholder in the exact order found in the `prepared_statement_bind_values` array.
 
-NOTE: Building count queries around a prepared statement is not supported at this time. Because jdbc paging uses count queries when `jdbc_paging_manual_mode` is false，jdbc paging is not supported with prepared statements at this time either. Therefore, `jdbc_paging_enabled`, `jdbc_page_size` settings are ignored when using prepared statements.
+NOTE: Building count queries around a prepared statement is not supported at this time. Because jdbc paging uses count queries when `jdbc_paging_mode` has value `auto`，jdbc paging is not supported with prepared statements at this time either. Therefore, `jdbc_paging_enabled`, `jdbc_page_size` settings are ignored when using prepared statements.
 
 Example:
 [source,ruby]
@@ -195,7 +196,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-jdbc_fetch_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-jdbc_page_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-jdbc_paging_enabled>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-jdbc_paging_manual_mode>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-jdbc_paging_mode>> |<<string,string>>, one of `["auto", "explicit"]`|No
 | <<plugins-{type}s-{plugin}-jdbc_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-jdbc_password_filepath>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-jdbc_pool_timeout>> |<<number,number>>|No
@@ -376,20 +377,20 @@ result-set. The limit size is set with `jdbc_page_size`.
 
 Be aware that ordering is not guaranteed between queries.
 
-[id="plugins-{type}s-{plugin}-jdbc_paging_manual_mode"]
-===== `jdbc_paging_manual_mode`
+[id="plugins-{type}s-{plugin}-jdbc_paging_mode"]
+===== `jdbc_paging_mode`
 
-  * Value type is <<boolean,boolean>>
-  * Default value is `false`
+  * Value can be any of: `auto`, `explicit`
+  * Default value is `"auto"`
 
-Whether to use manual mode during the JDBC paging
+Whether to use `explicit` or `auto` mode during the JDBC paging
 
-If false, your statement will be automatically surrounded by a count query and subsequent multiple paged queries (with `LIMIT` statement, etc.).
+If `auto`, your statement will be automatically surrounded by a count query and subsequent multiple paged queries (with `LIMIT` statement, etc.).
 
-If true, multiple queries (without a count query ahead) will be performed with your statement, until no more rows are retrieved.
+If `explicit`, multiple queries (without a count query ahead) will be performed with your statement, until no more rows are retrieved.
 You have to write your own paging conditions in your statement configuration.
 The `offset` and `size` parameters can be used in your statement (`size` equal to `jdbc_page_size`, and `offset` incremented by `size` for each query).
-When the number of rows returned by the query is not equal to 'size', SQL paging will be ended.
+When the number of rows returned by the query is not equal to `size`, SQL paging will be ended.
 Example:
 
 [source, ruby]
@@ -398,7 +399,7 @@ input {
   jdbc {
     statement => "SELECT id, mycolumn1, mycolumn2 FROM my_table WHERE id > :sql_last_value LIMIT :size OFFSET :offset",
     jdbc_paging_enabled => true,
-    jdbc_paging_manual_mode => true,
+    jdbc_paging_mode => "explicit",
     jdbc_page_size => 100000
   }
 }
@@ -410,7 +411,7 @@ input {
   jdbc {
     statement => "CALL fetch_my_data(:sql_last_value, :offset, :size)",
     jdbc_paging_enabled => true,
-    jdbc_paging_manual_mode => true,
+    jdbc_paging_mode => "explicit",
     jdbc_page_size => 100000
   }
 }

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -129,9 +129,8 @@ Here is the list:
 |sql_last_value | The value used to calculate which rows to query. Before any query is run,
 this is set to Thursday, 1 January 1970, or 0 if `use_column_value` is true and
 `tracking_column` is set. It is updated accordingly after subsequent queries are run.
-|offset, size| Values used in manual paging mode. Used in queries to explicitly implement
-the paging. Usable only if <<plugins-{type}s-{plugin}-jdbc_paging_enabled>> and
-<<plugins-{type}s-{plugin}-jdbc_paging_manual_mode>>  are enabled.
+|offset, size| Values used with manual paging mode to explicitly implement the paging.
+Supported only if <<plugins-{type}s-{plugin}-jdbc_paging_enabled>> and <<plugins-{type}s-{plugin}-jdbc_paging_manual_mode>> are enabled.
 |==========================================================
 
 Example:

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -55,6 +55,9 @@ module LogStash  module PluginMixins module Jdbc
       # Be aware that ordering is not guaranteed between queries.
       config :jdbc_paging_enabled, :validate => :boolean, :default => false
 
+      # Whether to use count query during the JDBC paging
+      config :jdbc_paging_avoid_count, :validate => :boolean, :default => false
+
       # JDBC page size
       config :jdbc_page_size, :validate => :number, :default => 100000
 
@@ -211,7 +214,7 @@ module LogStash  module PluginMixins module Jdbc
         open_jdbc_connection
         sql_last_value = @use_column_value ? @value_tracker.value : Time.now.utc
         @tracking_column_warning_sent = false
-        @statement_handler.perform_query(@database, @value_tracker.value, @jdbc_paging_enabled, @jdbc_page_size) do |row|
+        @statement_handler.perform_query(@database, @value_tracker.value, @jdbc_paging_enabled, @jdbc_paging_avoid_count, @jdbc_page_size) do |row|
           sql_last_value = get_column_value(row) if @use_column_value
           yield extract_values_from(row)
         end

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -55,8 +55,8 @@ module LogStash  module PluginMixins module Jdbc
       # Be aware that ordering is not guaranteed between queries.
       config :jdbc_paging_enabled, :validate => :boolean, :default => false
 
-      # Whether to use count query during the JDBC paging
-      config :jdbc_paging_avoid_count, :validate => :boolean, :default => false
+      # Whether to use manual mode during the JDBC paging
+      config :jdbc_paging_manual_mode, :validate => :boolean, :default => false
 
       # JDBC page size
       config :jdbc_page_size, :validate => :number, :default => 100000
@@ -214,7 +214,7 @@ module LogStash  module PluginMixins module Jdbc
         open_jdbc_connection
         sql_last_value = @use_column_value ? @value_tracker.value : Time.now.utc
         @tracking_column_warning_sent = false
-        @statement_handler.perform_query(@database, @value_tracker.value, @jdbc_paging_enabled, @jdbc_paging_avoid_count, @jdbc_page_size) do |row|
+        @statement_handler.perform_query(@database, @value_tracker.value, @jdbc_paging_enabled, @jdbc_paging_manual_mode, @jdbc_page_size) do |row|
           sql_last_value = get_column_value(row) if @use_column_value
           yield extract_values_from(row)
         end

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -214,7 +214,7 @@ module LogStash  module PluginMixins module Jdbc
         open_jdbc_connection
         sql_last_value = @use_column_value ? @value_tracker.value : Time.now.utc
         @tracking_column_warning_sent = false
-        @statement_handler.perform_query(@database, @value_tracker.value, @jdbc_paging_enabled, @jdbc_paging_manual_mode, @jdbc_page_size) do |row|
+        @statement_handler.perform_query(@database, @value_tracker.value, @jdbc_paging_enabled, @jdbc_page_size) do |row|
           sql_last_value = get_column_value(row) if @use_column_value
           yield extract_values_from(row)
         end

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -55,8 +55,8 @@ module LogStash  module PluginMixins module Jdbc
       # Be aware that ordering is not guaranteed between queries.
       config :jdbc_paging_enabled, :validate => :boolean, :default => false
 
-      # Whether to use manual mode during the JDBC paging
-      config :jdbc_paging_manual_mode, :validate => :boolean, :default => false
+      # Which pagination mode to use, automatic pagination or explicitly defined in the query.
+      config :jdbc_paging_mode, :validate => [ "auto", "explicit" ], :default => "auto"
 
       # JDBC page size
       config :jdbc_page_size, :validate => :number, :default => 100000

--- a/lib/logstash/plugin_mixins/jdbc/statement_handler.rb
+++ b/lib/logstash/plugin_mixins/jdbc/statement_handler.rb
@@ -27,7 +27,10 @@ module LogStash module PluginMixins module Jdbc
   class NormalStatementHandler < StatementHandler
     # Performs the query, respecting our pagination settings, yielding once per row of data
     # @param db [Sequel::Database]
-    # @param sql_last_value [Integet|DateTime|Time]
+    # @param sql_last_value [Integer|DateTime|Time]
+    # @param jdbc_paging_enabled [Boolean]
+    # @param jdbc_paging_manual_mode [Boolean]
+    # @param jdbc_page_size [Integer]
     # @yieldparam row [Hash{Symbol=>Object}]
     def perform_query(db, sql_last_value, jdbc_paging_enabled, jdbc_paging_manual_mode, jdbc_page_size)
       query = build_query(db, sql_last_value)

--- a/lib/logstash/plugin_mixins/jdbc/statement_handler.rb
+++ b/lib/logstash/plugin_mixins/jdbc/statement_handler.rb
@@ -6,7 +6,7 @@ module LogStash module PluginMixins module Jdbc
       if plugin.use_prepared_statements
         klass = PreparedStatementHandler
       else
-        if plugin.jdbc_paging_enabled && plugin.jdbc_paging_manual_mode
+        if plugin.jdbc_paging_enabled && plugin.jdbc_paging_mode == "explicit"
           klass = ExplicitPagingModeStatementHandler
         else
           klass = NormalStatementHandler

--- a/lib/logstash/plugin_mixins/jdbc/statement_handler.rb
+++ b/lib/logstash/plugin_mixins/jdbc/statement_handler.rb
@@ -29,10 +29,10 @@ module LogStash module PluginMixins module Jdbc
     # @param db [Sequel::Database]
     # @param sql_last_value [Integet|DateTime|Time]
     # @yieldparam row [Hash{Symbol=>Object}]
-    def perform_query(db, sql_last_value, jdbc_paging_enabled, jdbc_paging_avoid_count, jdbc_page_size)
+    def perform_query(db, sql_last_value, jdbc_paging_enabled, jdbc_paging_manual_mode, jdbc_page_size)
       query = build_query(db, sql_last_value)
       if jdbc_paging_enabled
-        if jdbc_paging_avoid_count
+        if jdbc_paging_manual_mode
           offset = 0
           loop do
             rows_in_page = 0
@@ -87,7 +87,7 @@ module LogStash module PluginMixins module Jdbc
     # @param db [Sequel::Database]
     # @param sql_last_value [Integet|DateTime|Time]
     # @yieldparam row [Hash{Symbol=>Object}]
-    def perform_query(db, sql_last_value, jdbc_paging_enabled, jdbc_paging_avoid_count, jdbc_page_size)
+    def perform_query(db, sql_last_value, jdbc_paging_enabled, jdbc_paging_manual_mode, jdbc_page_size)
       query = build_query(db, sql_last_value)
       query.each do |row|
         yield row

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.1.10'
+  s.version         = '5.2.0'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -329,6 +329,39 @@ describe LogStash::Inputs::Jdbc do
 
   end
 
+  context "when iterating result-set via paging (without count query)" do
+
+    let(:settings) do
+      {
+        "statement" => "SELECT * from test_table",
+        "jdbc_paging_enabled" => true,
+        "jdbc_paging_avoid_count" => true,
+        "jdbc_page_size" => 10
+      }
+    end
+
+    let(:num_rows) { 15 }
+
+    before do
+      plugin.register
+    end
+
+    after do
+      plugin.stop
+    end
+
+    it "should fetch all rows" do
+      num_rows.times do
+        db[:test_table].insert(:num => 1, :custom_time => Time.now.utc, :created_at => Time.now.utc)
+      end
+
+      plugin.run(queue)
+
+      expect(queue.size).to eq(num_rows)
+    end
+
+  end
+
   context "when using target option" do
     let(:settings) do
       {

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -329,13 +329,13 @@ describe LogStash::Inputs::Jdbc do
 
   end
 
-  context "when iterating result-set via paging (manual mode)" do
+  context "when iterating result-set via explicit paging mode" do
 
     let(:settings) do
       {
         "statement" => "SELECT * from test_table OFFSET :offset ROWS FETCH NEXT :size ROWS ONLY",
         "jdbc_paging_enabled" => true,
-        "jdbc_paging_manual_mode" => true,
+        "jdbc_paging_mode" => "explicit",
         "jdbc_page_size" => 10
       }
     end

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -333,7 +333,7 @@ describe LogStash::Inputs::Jdbc do
 
     let(:settings) do
       {
-        "statement" => "SELECT * from test_table",
+        "statement" => "SELECT * from test_table OFFSET :offset ROWS FETCH NEXT :size ROWS ONLY",
         "jdbc_paging_enabled" => true,
         "jdbc_paging_avoid_count" => true,
         "jdbc_page_size" => 10

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -329,13 +329,13 @@ describe LogStash::Inputs::Jdbc do
 
   end
 
-  context "when iterating result-set via paging (without count query)" do
+  context "when iterating result-set via paging (manual mode)" do
 
     let(:settings) do
       {
         "statement" => "SELECT * from test_table OFFSET :offset ROWS FETCH NEXT :size ROWS ONLY",
         "jdbc_paging_enabled" => true,
-        "jdbc_paging_avoid_count" => true,
+        "jdbc_paging_manual_mode" => true,
         "jdbc_page_size" => 10
       }
     end


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Added `jdbc_paging_mode` option to choose if use `explicit` pagination in statements and avoid the initial count query or use `auto` to delegate to the underlying library.

## What does this PR do?

This commit introduces a new configuration option to avoid the initial count select statement executed by Sequel in case of paginated queries. 
The paginated queries could be done now with initial count or not, in case `jdbc_paging_mode` is values `explicit` the plugin executes paged queries till it reach a page with less rows than the expected, instead of relying on the total row count.
In this case the SQL statement has to explicitly use the pagination keywords (like `LIMIT` and `OFFSET`) receiving as `:offset` and `:size` as implicit parameters.
When the paging mode `jdbc_paging_mode` is set to `auto` then the pagination happens automatically without the intervention of the user to create paginated query.


## Why is it important/What is the impact to the user?

In some circumstances, like stored procedure call with pagination bounds, the initial count query is simply not meaningful.
In cases where the pages to retrieve are few the initial count query could be an useful overhead.
In some complex nested queries the count could generate extra work that's not usefull

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist


- [x] check it with a local Logstash test.

## How to test this PR locally

- spin up a local DB
- configure a JDBC input query with pagination and with the new `jdbc_paging_avoid_count` and check it retrieves all the expected rows. In logs should be present a line for each paged query

```
input {
  jdbc {
    jdbc_driver_library => "/path/mysql-connector-java-8.0.26.jar"
    jdbc_driver_class => "Java::com.mysql.cj.jdbc.Driver"
    jdbc_connection_string => "jdbc:mysql://localhost:3306/test_logstash"

    jdbc_user => "user"
    jdbc_password => "s3cret"

    jdbc_default_timezone => "UTC"

    schedule => "* * * * *"

    use_column_value => true
    tracking_column => "log_id"
    tracking_column_type => "numeric"
    last_run_metadata_path => ".last_run"
    
    statement => "SELECT * FROM data_log WHERE log_id > :sql_last_value LIMIT :size OFFSET :offset"
    jdbc_paging_enabled => true
    jdbc_page_size => 7
    jdbc_paging_avoid_count => true
  }
}

output {
  stdout {
    codec => "rubydebug"
  }
}
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Superseeds #90

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
### Simple query with small result sets
In a simple query like:
```sql
SELECT * from test_table
```
the automatic pagination would generate the count query plus the paginated queries.
With small resultsets it issues 2 queries instead of one query.

### A stored procedure that requires pagination information. Suppose you have a stored like
 ```sql
CALL fetch_my_data(:sql_last_value, <offset>, <size>)
```
the automatic pagination would generate an invalid SQL statement:
```sql
SELECT count(*) AS count FROM ( CALL fetch_my_data(:sql_last_value) ) AS t1 LIMIT 1
SELECT * FROM ( CALL fetch_my_data(:sql_last_value) ) AS t1 LIMIT 10 OFFSET 0
.
.
```
which is not what's expected.

### Nested queries with pagination on the inner query
Suppose the query you want to paginate is the inner on, like in:
```sql
SELECT * FROM test_table2 WHERE id IN (SELECT * FROM test_table LIMIT <offset>, <size>)
```

Without this feature, the automatic pagination would generate the following SQL:
```sql
SELECT count(*) AS count FROM ( 
  SELECT * FROM test_table2 WHERE id IN (SELECT * FROM test_table) 
) AS t1 LIMIT 1;

SELECT * FROM ( 
  SELECT * FROM test_table2 WHERE id IN (SELECT * FROM test_table) 
) AS t1 LIMIT 10 OFFSET 0;
.
.
```
which is the pagination applied to the outer query instead of the inner one.

