### PR TITLE
Refactor: to explicit Java (driver) class name loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.9
+  - Refactor: to explicit Java (driver) class name loading [#96](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/96),
+    the change is expected to provide a more robust fix for the driver loading issue [#83](https://github.com/logstash-plugins/logstash-integration-jdbc/issues/83).
+
 ## 5.1.8
   - Fix the blocking pipeline reload and shutdown when connectivity issues happen [#85](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/85)
 

--- a/lib/logstash/plugin_mixins/jdbc/common.rb
+++ b/lib/logstash/plugin_mixins/jdbc/common.rb
@@ -30,16 +30,15 @@ module LogStash module PluginMixins module Jdbc
       begin
         load_driver_jars
         begin
-          @driver_impl = Sequel::JDBC.load_driver(normalized_driver_class)
-        rescue Sequel::AdapterNotFound => e # Sequel::AdapterNotFound, "#{@jdbc_driver_class} not loaded"
-          # fix this !!!
+          @driver_impl = load_jdbc_driver_class
+        rescue => e
           message = if jdbc_driver_library_set?
                       "Are you sure you've included the correct jdbc driver in :jdbc_driver_library?"
                     else
                       ":jdbc_driver_library is not set, are you sure you included " +
                           "the proper driver client libraries in your classpath?"
                     end
-          raise LogStash::PluginLoadingError, "#{e}. #{message} #{e.backtrace}"
+          raise LogStash::PluginLoadingError, "#{e.inspect}. #{message}"
         end
       ensure
         DRIVERS_LOADING_LOCK.unlock()
@@ -71,16 +70,13 @@ module LogStash module PluginMixins module Jdbc
       !@jdbc_driver_library.nil? && !@jdbc_driver_library.empty?
     end
 
-    # normalizing the class name to always have a Java:: prefix
-    # is helpful since JRuby is only able to directly load class names
-    # whose top-level package is com, org, java, javax
-    # There are many jdbc drivers that use cc, io, net, etc.
-    def normalized_driver_class
-      if @jdbc_driver_class.start_with?("Java::", "Java.")
-        @jdbc_driver_class
-      else
-        "Java::#{@jdbc_driver_class}"
-      end
+    def load_jdbc_driver_class
+      # sub a potential: 'Java::org::my::Driver' to 'org.my.Driver'
+      class_name = @jdbc_driver_class.gsub('::', '.').sub(/^Java\./, '')
+      # NOTE: JRuby's Java::JavaClass.for_name which considers the custom class-loader(s)
+      # in 9.3 the API changed and thus to avoid surprises we go down to the Java API :
+      JRuby.runtime.getJavaSupport.loadJavaClass(class_name) # throws ClassNotFoundException
     end
+
   end
 end end end

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.1.8'
+  s.version         = '5.1.9'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1249,32 +1249,6 @@ describe LogStash::Inputs::Jdbc do
     end
   end
 
-  context 'connection errors' do
-
-    it "should log native Java cause" do
-      mixin_settings['connection_retry_attempts'] = 1
-
-      allow(Sequel).to receive(:connect).and_raise(Sequel::PoolTimeout)
-      expect(plugin.logger).to receive(:error).with("Failed to connect to database. 0 second timeout exceeded. Trying again.")
-      expect(plugin.logger).to receive(:error).with("Failed to connect to database. 0 second timeout exceeded. Tried 2 times.")
-      expect do
-        plugin.register
-        plugin.run(queue)
-      end.to raise_error(Sequel::PoolTimeout)
-    end
-
-    # it "should log Java driver error" do
-    #   plugin.register
-    #   expect( plugin.logger )
-    #   # expect(org.apache.logging.log4j.LogManager).to receive(:solve_for).and_wrap_original { |m, *args| m.call(*args).first(5) }
-    #   q = Queue.new
-    #   expect do
-    #     plugin.run(q)
-    #   end.to raise_error(::Sequel::DatabaseConnectionError)
-    # end
-
-  end
-
   context "when encoding of some columns need to be changed" do
 
     let(:settings) {{ "statement" => "SELECT * from test_table" }}


### PR DESCRIPTION
This is a second attempt on fixing https://github.com/logstash-plugins/logstash-integration-jdbc/issues/83 as it seems to still manifest even with locking.

#### Few more observations on what's going on (with #83):
- [`Sequel::JDBC.load_driver`](https://github.com/jeremyevans/sequel/blob/5.51.0/lib/sequel/adapters/jdbc.rb#L55) ends up doing an `eval` on the input (e.g. `Java::oracle.jdbc.driver.OracleDriver`)
- the `eval` sometimes fails with a `NameError` (having multiple drivers and executing threads is a factor)
- as hinted previously the problem seems to be specific to `'com.sybase.jdbc4.jdbc.SybDriver'` driver (+ having another driver such as `'oracle.jdbc.driver.OracleDriver'` around as well)
- JRuby might have an underlying bug with `eval` and setting up the Java package structure for the drivers
- at [one point an ugly error came out](https://gist.github.com/kares/850767d4be4d5323b068af9585e45d4a#file-load_driver_xfail-txt-L18-L35) - which indicates an underlying Java driver loading issue (although this might have been caused by the concurrent loading of different drivers - registering with `DriverManager`)

- the issue **only happens when drivers are on the LS class-path** (setting `jdbc_driver_library =>` did not reproduce!)
- with the changes in this PR the issue **did no longer reproduce even if drivers were on the LS class-path**

A bit simplified reproducer (does not need to run Logstash): https://gist.github.com/kares/850767d4be4d5323b068af9585e45d4a

*p.s. Previous changes (from https://github.com/logstash-plugins/logstash-integration-jdbc/pull/84) could be reverted but I am keeping them in (they do not hurt - the lock just slows down multiple jdbc plugins starting), for now.*

---

More investigation might be needed for an actual underlying cause (as well as the potential JRuby bug) but the changes presented here make sense regardless - skipping `eval` and doing a simply `Class.forName` is very similar to what an actual Java JDBC application would attempt to do (and should hopefully make debugging the problem easier).