### PR TITLE
Fix: compatibility with all (>= 3.0) rufus-scheduler versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,7 @@
 import:
-- logstash-plugins/.ci:travis/travis.yml@1.x
+  - logstash-plugins/.ci:travis/travis.yml@1.x
+
+env:
+  jobs: # test with old scheduler version (3.0 was locked in LS 7.x)
+    - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9
+    - ELASTIC_STACK_VERSION=6.x RUFUS_SCHEDULER_VERSION=3.0.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.4
+  - Fix: compatibility with all (>= 3.0) rufus-scheduler versions [#97](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/97) 
+
 ## 5.2.3
   - Performance: avoid contention on scheduler execution [#103](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/103)
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,5 @@ if Dir.exist?(logstash_path) && use_logstash_source
   gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
   gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
 end
+
+gem 'rufus-scheduler', ENV['RUFUS_SCHEDULER_VERSION'] if ENV['RUFUS_SCHEDULER_VERSION']

--- a/lib/logstash/filters/jdbc/loader_schedule.rb
+++ b/lib/logstash/filters/jdbc/loader_schedule.rb
@@ -4,72 +4,36 @@ require "rufus/scheduler"
 
 module LogStash module Filters module Jdbc
   class LoaderSchedule < Validatable
-    attr_reader :schedule_frequency, :loader_schedule
+    attr_reader :loader_schedule
 
     def to_log_string
-      message = ""
-      message.concat "these months in the year [#{@cronline.months.to_a.join(", ")}];" unless @cronline.months.nil?
-      if fugit_cron?
-        message.concat "these days in the month [#{@cronline.monthdays.to_a.join(", ")}];" unless @cronline.monthdays.nil?
+      if @cronline.frequency == @cronline.brute_frequency
+        "#{@cronline.frequency} seconds"
       else
-        message.concat "these days in the month [#{@cronline.days.to_a.join(", ")}];" unless @cronline.days.nil?
+        "#{@cronline.frequency} (brute: #{@cronline.brute_frequency}) seconds"
       end
-      message.concat "these hours in the day [#{@cronline.hours.to_a.join(", ")}];" unless @cronline.hours.nil?
-      message.concat "these minutes in the hour [#{@cronline.minutes.to_a.join(", ")}];" unless @cronline.minutes.nil?
-      message.concat "these seconds in the minute [#{@cronline.seconds.to_a.join(", ")}]" unless @cronline.seconds.nil?
-      if !message.empty?
-        message.prepend "Scheduled for: "
-      end
-      message
     end
 
     private
-
-    def post_initialize
-      if valid?
-        # From the Rufus::Scheduler docs:
-        #   By default, rufus-scheduler sleeps 0.300 second between every step.
-        #   At each step it checks for jobs to trigger and so on.
-        # set the frequency to 2.5 seconds if we are not reloading in the seconds timeframe
-        # rufus scheduler thread should respond to stop quickly enough.
-        if only_seconds_set?
-          @schedule_frequency = 0.3
-        else
-          @schedule_frequency = 2.5
-        end
-      end
-    end
-
-    def only_seconds_set?
-      @cronline.seconds &&
-        @cronline.minutes.nil? &&
-        @cronline.hours.nil? &&
-        # Rufus <= 3.4 Rufus::Scheduler::CronLine#days
-        # since 3.5.0 using Fugit::Cron which does not use #days
-        (!@cronline.respond_to?(:days) || @cronline.days.nil?) &&
-        # Rufus 3.4.x seems to have missed the monthdays reader
-        (!@cronline.respond_to?(:monthdays) || @cronline.monthdays.nil?) &&
-        @cronline.months.nil? &&
-        @cronline.weekdays.nil?
-    end
 
     def fugit_cron?
       defined?(::Fugit) && @cronline.is_a?(::Fugit::Cron)
     end
 
+    # @overload
     def parse_options
       @loader_schedule = @options
 
-      unless @loader_schedule.is_a?(String)
+      if @loader_schedule.is_a?(String)
+        begin
+          # Rufus::Scheduler 3.0 - 3.6 methods signature: parse_cron(o, opts)
+          # since Rufus::Scheduler 3.7 methods signature: parse_cron(o, opts={})
+          @cronline = Rufus::Scheduler.parse_cron(@loader_schedule, {})
+        rescue => e
+          @option_errors << "The loader_schedule option is invalid: #{e.message}"
+        end
+      else
         @option_errors << "The loader_schedule option must be a string"
-      end
-
-      begin
-        # Rufus::Scheduler 3.0 - 3.6 methods signature: parse_cron(o, opts)
-        # since Rufus::Scheduler 3.7 methods signature: parse_cron(o, opts={})
-        @cronline = Rufus::Scheduler.parse_cron(@loader_schedule, {})
-      rescue => e
-        @option_errors << "The loader_schedule option is invalid: #{e.message}"
       end
 
       @valid = @option_errors.empty?

--- a/lib/logstash/filters/jdbc/loader_schedule.rb
+++ b/lib/logstash/filters/jdbc/loader_schedule.rb
@@ -6,18 +6,6 @@ module LogStash module Filters module Jdbc
   class LoaderSchedule < Validatable
     attr_reader :loader_schedule
 
-    def to_log_string
-      if @cronline.respond_to?(:rough_frequency) # Fugit::Cron
-        frequency = @cronline.rough_frequency
-      else # old Rufus::Scheduler
-        frequency = @cronline.frequency
-        if @cronline.seconds
-          frequency = @cronline.brute_frequency
-        end
-      end
-      "#{frequency} seconds"
-    end
-
     private
 
     # @overload

--- a/lib/logstash/filters/jdbc/loader_schedule.rb
+++ b/lib/logstash/filters/jdbc/loader_schedule.rb
@@ -20,10 +20,6 @@ module LogStash module Filters module Jdbc
 
     private
 
-    def fugit_cron?
-      defined?(::Fugit) && @cronline.is_a?(::Fugit::Cron)
-    end
-
     # @overload
     def parse_options
       @loader_schedule = @options

--- a/lib/logstash/filters/jdbc/loader_schedule.rb
+++ b/lib/logstash/filters/jdbc/loader_schedule.rb
@@ -7,11 +7,15 @@ module LogStash module Filters module Jdbc
     attr_reader :loader_schedule
 
     def to_log_string
-      if @cronline.frequency == @cronline.brute_frequency
-        "#{@cronline.frequency} seconds"
-      else
-        "#{@cronline.frequency} (brute: #{@cronline.brute_frequency}) seconds"
+      if @cronline.respond_to?(:rough_frequency) # Fugit::Cron
+        frequency = @cronline.rough_frequency
+      else # old Rufus::Scheduler
+        frequency = @cronline.frequency
+        if @cronline.seconds
+          frequency = @cronline.brute_frequency
+        end
       end
+      "#{frequency} seconds"
     end
 
     private

--- a/lib/logstash/filters/jdbc/repeating_load_runner.rb
+++ b/lib/logstash/filters/jdbc/repeating_load_runner.rb
@@ -3,8 +3,6 @@ require_relative "single_load_runner"
 
 module LogStash module Filters module Jdbc
   class RepeatingLoadRunner < SingleLoadRunner
-   # info - attr_reader :local, :loaders, :preloaders
-
     def repeated_load
       local.repopulate_all(loaders)
       @reload_counter.increment

--- a/lib/logstash/filters/jdbc/single_load_runner.rb
+++ b/lib/logstash/filters/jdbc/single_load_runner.rb
@@ -2,8 +2,6 @@
 require_relative 'db_object'
 
 module LogStash module Filters module Jdbc
-  # Handler impl for scheduled jobs from Rufus::Scheduler.
-  # @see #call
   class SingleLoadRunner
 
     attr_reader :local, :loaders, :preloaders

--- a/lib/logstash/filters/jdbc/single_load_runner.rb
+++ b/lib/logstash/filters/jdbc/single_load_runner.rb
@@ -28,11 +28,6 @@ module LogStash module Filters module Jdbc
     def repeated_load
     end
 
-    # @note hook called Handler by Rufus::Scheduler
-    def call
-      repeated_load
-    end
-
     def reload_count
       @reload_counter.value
     end

--- a/lib/logstash/filters/jdbc/single_load_runner.rb
+++ b/lib/logstash/filters/jdbc/single_load_runner.rb
@@ -2,6 +2,8 @@
 require_relative 'db_object'
 
 module LogStash module Filters module Jdbc
+  # Handler impl for scheduled jobs from Rufus::Scheduler.
+  # @see #call
   class SingleLoadRunner
 
     attr_reader :local, :loaders, :preloaders
@@ -26,6 +28,7 @@ module LogStash module Filters module Jdbc
     def repeated_load
     end
 
+    # @note hook called Handler by Rufus::Scheduler
     def call
       repeated_load
     end

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -191,7 +191,6 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
     @processor = Jdbc::LookupProcessor.new(@local_lookups, global_lookup_options)
     runner_args.unshift(@processor.local)
     if @loader_schedule
-      args = []
       @loader_runner = Jdbc::RepeatingLoadRunner.new(*runner_args)
       @loader_runner.initial_load
       cronline = Jdbc::LoaderSchedule.new(@loader_schedule)

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -195,9 +195,7 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
       @loader_runner = Jdbc::RepeatingLoadRunner.new(*runner_args)
       @loader_runner.initial_load
       cronline = Jdbc::LoaderSchedule.new(@loader_schedule)
-      if cronline.valid?
-        logger.info("Loaders will execute every #{cronline.to_log_string}", loader_schedule: @loader_schedule)
-      end
+      logger.info("Loaders will execute every #{cronline.to_log_string}", loader_schedule: @loader_schedule)
       @scheduler = LogStash::PluginMixins::Jdbc::Scheduler.
           start_cron_scheduler(@loader_schedule, thread_name: "[#{id}]-jdbc_static__scheduler") { @loader_runner.repeated_load }
     else

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -3,6 +3,7 @@ require "logstash-integration-jdbc_jars"
 require "logstash/filters/base"
 require "logstash/namespace"
 require "logstash/plugin_mixins/ecs_compatibility_support"
+require "logstash/plugin_mixins/jdbc/scheduler"
 require_relative "jdbc/loader"
 require_relative "jdbc/loader_schedule"
 require_relative "jdbc/repeating_load_runner"
@@ -194,13 +195,11 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
       @loader_runner = Jdbc::RepeatingLoadRunner.new(*runner_args)
       @loader_runner.initial_load
       cronline = Jdbc::LoaderSchedule.new(@loader_schedule)
-      cronline.to_log_string.tap do |msg|
-        logger.info("Scheduler operations: #{msg}") unless msg.empty?
+      if cronline.valid?
+        logger.info("Loaders will execute every #{cronline.to_log_string}", loader_schedule: @loader_schedule)
       end
-      logger.info("Scheduler scan for work frequency is: #{cronline.schedule_frequency}")
-      rufus_args = {:max_work_threads => 1, :frequency => cronline.schedule_frequency}
-      @scheduler = Rufus::Scheduler.new(rufus_args)
-      @scheduler.cron(cronline.loader_schedule, @loader_runner)
+      @scheduler = LogStash::PluginMixins::Jdbc::Scheduler.
+          start_cron_scheduler(@loader_schedule, thread_name: "[#{id}]<jdbc_static__scheduler") { @loader_runner.repeated_load }
     else
       @loader_runner = Jdbc::SingleLoadRunner.new(*runner_args)
       @loader_runner.initial_load

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -199,7 +199,7 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
         logger.info("Loaders will execute every #{cronline.to_log_string}", loader_schedule: @loader_schedule)
       end
       @scheduler = LogStash::PluginMixins::Jdbc::Scheduler.
-          start_cron_scheduler(@loader_schedule, thread_name: "[#{id}]<jdbc_static__scheduler") { @loader_runner.repeated_load }
+          start_cron_scheduler(@loader_schedule, thread_name: "[#{id}]-jdbc_static__scheduler") { @loader_runner.repeated_load }
     else
       @loader_runner = Jdbc::SingleLoadRunner.new(*runner_args)
       @loader_runner.initial_load

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -295,19 +295,8 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
     load_driver
     if @schedule
       # input thread (Java) name example "[my-oracle]<jdbc"
-      @scheduler = LogStash::PluginMixins::Jdbc::Scheduler.new(
-          :max_work_threads => 1,
-          :thread_name => "[#{id}]<jdbc__scheduler",
-          # amount the scheduler thread sleeps between checking whether jobs
-          # should trigger, default is 0.3 which is a bit too often ...
-          # in theory the cron expression '* * * * * *' supports running jobs
-          # every second but this is very rare, we could potentially go higher
-          :frequency => 1.0,
-      )
-      @scheduler.schedule_cron @schedule do
-        execute_query(queue)
-      end
-
+      @scheduler = LogStash::PluginMixins::Jdbc::Scheduler.
+          start_cron_scheduler(@schedule, thread_name: "[#{id}]<jdbc__scheduler") { execute_query(queue) }
       @scheduler.join
     else
       execute_query(queue)

--- a/lib/logstash/plugin_mixins/jdbc/scheduler.rb
+++ b/lib/logstash/plugin_mixins/jdbc/scheduler.rb
@@ -12,6 +12,34 @@ module LogStash module PluginMixins module Jdbc
     TimeImpl = defined?(Rufus::Scheduler::EoTime) ? Rufus::Scheduler::EoTime :
                    (defined?(Rufus::Scheduler::ZoTime) ? Rufus::Scheduler::ZoTime : ::Time)
 
+    # @param cron [String] cron-line
+    # @param opts [Hash] scheduler options
+    # @return scheduler instance
+    def self.start_cron_scheduler(cron, opts = {}, &block)
+      unless block_given?
+        raise ArgumentError, 'missing (cron scheduler) block - worker task to execute'
+      end
+      scheduler = new_scheduler(opts)
+      scheduler.schedule_cron(cron, &block)
+      scheduler
+    end
+
+    # @param opts [Hash] scheduler options
+    # @return scheduler instance
+    def self.new_scheduler(opts)
+      unless opts.key?(:thread_name)
+        raise ArgumentError, 'thread_name: option is required to be able to distinguish multiple scheduler threads'
+      end
+      opts[:max_work_threads] ||= 1
+      # amount the scheduler thread sleeps between checking whether jobs
+      # should trigger, default is 0.3 which is a bit too often ...
+      # in theory the cron expression '* * * * * *' supports running jobs
+      # every second but this is very rare, we could potentially go higher
+      opts[:frequency] ||= 1.0
+
+      new(opts)
+    end
+
     # @overload
     def timeout_jobs
       # Rufus relies on `Thread.list` which is a blocking operation and with many schedulers

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.2.3'
+  s.version         = '5.2.4'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -34,7 +34,9 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'tzinfo'
   s.add_runtime_dependency 'tzinfo-data'
-  s.add_runtime_dependency 'rufus-scheduler', '>= 3.5.2'
+  # plugin maintains compatibility with < 3.5 (3.0.9)
+  # but works with newer rufus-scheduler >= 3.5 as well
+  s.add_runtime_dependency 'rufus-scheduler'
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.3'
   s.add_runtime_dependency "logstash-mixin-validator_support", '~> 1.0'
   s.add_runtime_dependency "logstash-mixin-event_support", '~> 1.0'

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'tzinfo'
   s.add_runtime_dependency 'tzinfo-data'
-  s.add_runtime_dependency 'rufus-scheduler', '~> 3.0.9'
+  s.add_runtime_dependency 'rufus-scheduler', '>= 3.5.2'
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.3'
   s.add_runtime_dependency "logstash-mixin-validator_support", '~> 1.0'
   s.add_runtime_dependency "logstash-mixin-event_support", '~> 1.0'

--- a/spec/filters/jdbc/repeating_load_runner_spec.rb
+++ b/spec/filters/jdbc/repeating_load_runner_spec.rb
@@ -17,7 +17,7 @@ module LogStash module Filters module Jdbc
         expect(local_db).to receive(:populate_all).once.with(loaders)
         expect(local_db).to receive(:repopulate_all).once.with(loaders)
         runner.initial_load
-        subject.call
+        subject.repeated_load
       end
     end
   end


### PR DESCRIPTION
The work here is meant to get the plugin working with up-to-date **rufus-scheduler** versions.

ATM, LS 7.x is stuck with gem version **3.0.9** (due plugins pinning `~> 3.0.9`), see https://github.com/elastic/logstash/issues/12931


The previous *rufus-scheduler* `< 3.5` lock (got tightened in version 3.2.2 to `~> 3.0.9`), was due Rufus moving the `Rufus::Scheduler::CronLine` class into a [standalone gem](https://github.com/floraison/fugit) (`Fugit::Cron`) with a slightly changed API (removed `#days` method). That feature was only used for logging and is now replaced by simply logging the calculated frequency of the cron expression.

Also, part of the PR our custom `Scheduler` sub-class was reviewed for re-use with a new API draft to use across plugins (as we plan to extract the `Scheduler` mixin bits into its own gem), the idea being using a factory method to provide everything in one step e.g.
```ruby
      @scheduler = ...::Scheduler.
          start_cron_scheduler(schedule, thread_name: "[#{id}]<...") { do_periodic_work(queue) }
      @scheduler.join
```
Most plugins will only need ^^^ this, the JDBC plugin still rely on some `Rufus::Scheduler` api (not worth to push the scheduler externalization that much further atm).

~~*NOTE: we should consider not using any 3.1 - 3.5 version which had stopped using **tzinfo** gem for a self invented `Rufus::ZoTime` class, tzinfo is (transitively) used again in version >= 3.6 through an added gem.*~~
