### PR TITLE
Performance: avoid contention on scheduler execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.3
+  - Performance: avoid contention on scheduler execution [#103](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/103)
+
 ## 5.2.2
   - Feat: name scheduler threads + redirect error logging [#102](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/102)
 

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -302,7 +302,7 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
           # should trigger, default is 0.3 which is a bit too often ...
           # in theory the cron expression '* * * * * *' supports running jobs
           # every second but this is very rare, we could potentially go higher
-          :frequency => 0.9,
+          :frequency => 1.0,
       )
       @scheduler.schedule_cron @schedule do
         execute_query(queue)

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -296,7 +296,13 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
     if @schedule
       # input thread (Java) name example "[my-oracle]<jdbc"
       @scheduler = LogStash::PluginMixins::Jdbc::Scheduler.new(
-          :max_work_threads => 1, :thread_name => "[#{id}]<jdbc__scheduler"
+          :max_work_threads => 1,
+          :thread_name => "[#{id}]<jdbc__scheduler",
+          # amount the scheduler thread sleeps between checking whether jobs
+          # should trigger, default is 0.3 which is a bit too often ...
+          # in theory the cron expression '* * * * * *' supports running jobs
+          # every second but this is very rare, we could potentially go higher
+          :frequency => 0.9,
       )
       @scheduler.schedule_cron @schedule do
         execute_query(queue)

--- a/lib/logstash/plugin_mixins/jdbc/scheduler.rb
+++ b/lib/logstash/plugin_mixins/jdbc/scheduler.rb
@@ -27,7 +27,7 @@ module LogStash module PluginMixins module Jdbc
 
     # @overload
     def work_threads(query = :all)
-      if query.nil? # our special case from JobDecorator#start_work_thread
+      if query == :__all_no_cache__ # special case from JobDecorator#start_work_thread
         @_work_threads = nil # when a new worker thread is being added reset
         return super(:all)
       end
@@ -108,14 +108,14 @@ module LogStash module PluginMixins module Jdbc
     module JobDecorator
 
       def start_work_thread
-        prev_thread_count = @scheduler.work_threads(nil).size
+        prev_thread_count = @scheduler.work_threads.size
 
         ret = super() # does not return Thread instance in 3.0
 
-        work_threads = @scheduler.work_threads(nil)
+        work_threads = @scheduler.work_threads(:__all_no_cache__)
         while prev_thread_count == work_threads.size # very unlikely
           Thread.pass
-          work_threads = @scheduler.work_threads(nil)
+          work_threads = @scheduler.work_threads(:__all_no_cache__)
         end
 
         work_thread_name_prefix = @scheduler.work_thread_name_prefix

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.2.2'
+  s.version         = '5.2.3'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/plugin_mixins/jdbc/scheduler_spec.rb
+++ b/spec/plugin_mixins/jdbc/scheduler_spec.rb
@@ -49,4 +49,30 @@ describe LogStash::PluginMixins::Jdbc::Scheduler do
 
   end
 
+  context 'work threads' do
+
+    let(:opts) { super().merge :max_work_threads => 3 }
+
+    let(:counter) { java.util.concurrent.atomic.AtomicLong.new(0) }
+
+    before do
+      scheduler.schedule_cron('* * * * * *') { counter.increment_and_get; sleep 3.25 } # every second
+    end
+
+    it "are working" do
+      sleep(0.05) while counter.get == 0
+      expect( scheduler.work_threads.size ).to eql 1
+      sleep(0.05) while counter.get == 1
+      expect( scheduler.work_threads.size ).to eql 2
+      sleep(0.05) while counter.get == 2
+      expect( scheduler.work_threads.size ).to eql 3
+
+      sleep 1.25
+      expect( scheduler.work_threads.size ).to eql 3
+      sleep 1.25
+      expect( scheduler.work_threads.size ).to eql 3
+    end
+
+  end
+
 end


### PR DESCRIPTION
What we're after here is to avoid `Thread.list` blocking operation, which in JRuby means walking a synchronized Map.

A lot of Ruby threads in the system trying to `Thread.list` will lead to thread contending (blocked) for execution ...

`Rufus::Scheduler` uses `Thread.list` when figuring out which are the worker/scheduler threads it started.
This is working but a bit unfortunate and might be the cause for issues such as https://github.com/logstash-plugins/logstash-integration-jdbc/issues/88 (if there are multiple scheduler instances started from plugins - e.g. multiple jdbc inputs or http_poller or elasticsearch inputs with a `schedule => ...`).

Implementation wise there's 3 changes that improve performance:

1. less [scheduler thread ticks](https://github.com/jmettraux/rufus-scheduler/blob/v3.0.9/lib/rufus/scheduler.rb#L564) (sleep for 1.0 instead of 0.3)
![Screenshot from 2022-02-09 14-29-08](https://user-images.githubusercontent.com/45967/153389167-2dd5158b-39a5-4fc1-8e51-be5df5392e6b.png)


2. avoid [timeout_jobs](https://github.com/jmettraux/rufus-scheduler/blob/v3.0.9/lib/rufus/scheduler.rb#L562) doing a `Thread.list` if the timeout feature is not used (the plugin does not use timeouts)
![Screenshot from 2022-02-09 14-45-33](https://user-images.githubusercontent.com/45967/153389267-4a09f3a1-3a36-4d27-98c0-d78f2a418f97.png)
NOTE: this accounts for most of the improvements ...

3. finally there's still a `list` operation whenever the [job is about to be executed](https://github.com/jmettraux/rufus-scheduler/blob/v3.0.9/lib/rufus/scheduler/jobs.rb#L323)
![Screenshot from 2022-02-09 15-48-48](https://user-images.githubusercontent.com/45967/153389356-e09d7c69-46bb-4562-860c-c2a50b614bba.png)
NOTE: the reason we re-def `worker_threads` and cache them - there's no more locking operations (the remaining Random contention is due to using `Kernel.rand` in a local testing scenario and does not happen in production).


The recording screenshots are from a local emulated run, which is a bit far fetched: 600 schedulers with a 10s interval cron schedule. Still do not have a good enough explanation for a complete scheduler stop, what I was able to accomplish locally is some schedulers skipping one, two, sometimes three four (10 second) runs.

---

For now we're not sure whether there is another bug with `Rufus::Scheduler` (3.0.9) that would cause #88.

The plan is to have the patch tested with potentially many JDBC inputs, if the input stopping issue persist we might need to investigate further. Upon succession the `< Scheduler` sub-class should be extracted into it's own mixin to be usable by all plugins (not just JDBC), ideally the rufus-scheduler would also be updated to latest version.
The overrides should be iterated upon to avoid using `Thread.list` in the library completely and submitting a patch upstream.