### PR TITLE
Removes double creation of FileHandler used in value tracking

### DIFF
--- a/lib/logstash/plugin_mixins/jdbc/value_tracking.rb
+++ b/lib/logstash/plugin_mixins/jdbc/value_tracking.rb
@@ -6,9 +6,6 @@ module LogStash module PluginMixins module Jdbc
 
     def self.build_last_value_tracker(plugin)
       handler = plugin.record_last_run ? FileHandler.new(plugin.last_run_metadata_path) : NullFileHandler.new(plugin.last_run_metadata_path)
-      if plugin.record_last_run
-        handler = FileHandler.new(plugin.last_run_metadata_path)
-      end
       if plugin.clean_run
         handler.clean
       end


### PR DESCRIPTION
This commits removes redundant creation of FileHandler instance.