### PR TITLE
Updates storage path for internal data to use subfolder in Logstash's `data.path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.6
+  - Fix: change default path of 'last_run_metadata_path' to be rooted in the LS data.path folder and not in $HOME [#106](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/106)
+
 ## 5.2.5
   - Fix: do not execute more queries with debug logging [#109](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/109)
 

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -152,9 +152,7 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
   public
 
   def register
-    # This check is Logstash 5 specific.  If the class does not exist, and it
-    # won't in older versions of Logstash, then we need to set it to nil.
-    @settings = defined?(LogStash::SETTINGS) ? LogStash::SETTINGS : nil
+    @settings = LogStash::SETTINGS
 
     prepare_data_dir
     prepare_runner

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -189,7 +189,7 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
 
     # later, when local persistent databases are allowed set this property to LS_HOME/data/jdbc-static/
     # must take multi-pipelines into account and more than one config using the same jdbc-static settings
-    path_data = Pathname.new(LogStash::SETTINGS.get_value("path.data")).join("plugins", "filter", "jdbc_static")
+    path_data = Pathname.new(LogStash::SETTINGS.get_value("path.data")).join("plugins", "shared", "derby_home")
     path_data.mkpath
     java.lang.System.setProperty("derby.system.home", path_data.to_path)
     logger.info("derby.system.home is: #{java.lang.System.getProperty("derby.system.home")}")

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -152,8 +152,6 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
   public
 
   def register
-    @settings = LogStash::SETTINGS
-
     prepare_data_dir
     prepare_runner
   end
@@ -183,15 +181,15 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
       begin
         ::File.delete()
       rescue Errno::EPERM => e
-        @logger.warn("Can't move file #{derby_log} due to access permissions")
+        @logger.warn("Can't delete file #{derby_log} due to access permissions")
       rescue e
-        @logger.warn("Can't move file #{derby_log}", {message => e.message})
+        @logger.warn("Can't delete file #{derby_log}", {message => e.message})
       end
     end
 
     # later, when local persistent databases are allowed set this property to LS_HOME/data/jdbc-static/
     # must take multi-pipelines into account and more than one config using the same jdbc-static settings
-    path_data = Pathname.new(@settings.get_value("path.data")).join("plugins", "filter", "jdbc_static")
+    path_data = Pathname.new(LogStash::SETTINGS.get_value("path.data")).join("plugins", "filter", "jdbc_static")
     path_data.mkpath
     java.lang.System.setProperty("derby.system.home", path_data.to_path)
     logger.info("derby.system.home is: #{java.lang.System.getProperty("derby.system.home")}")

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -152,6 +152,10 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
   public
 
   def register
+    # This check is Logstash 5 specific.  If the class does not exist, and it
+    # won't in older versions of Logstash, then we need to set it to nil.
+    @settings = defined?(LogStash::SETTINGS) ? LogStash::SETTINGS : nil
+
     prepare_data_dir
     prepare_runner
   end
@@ -177,7 +181,7 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
   def prepare_data_dir
     # later, when local persistent databases are allowed set this property to LS_HOME/data/jdbc-static/
     # must take multi-pipelines into account and more than one config using the same jdbc-static settings
-    path_data = Pathname.new(settings.get_value("path.data")).join("plugins", "filter", "jdbc_static")
+    path_data = Pathname.new(@settings.get_value("path.data")).join("plugins", "filter", "jdbc_static")
     path_data.mkpath
     java.lang.System.setProperty("derby.system.home", path_data.to_path)
     logger.info("derby.system.home is: #{java.lang.System.getProperty("derby.system.home")}")

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -177,6 +177,18 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
   private
 
   def prepare_data_dir
+    # cleanup existing Derby file left behind in $HOME
+    derby_log = "#{ENV['HOME']}/derby.log"
+    if (::File.exist?(derby_log))
+      begin
+        ::File.delete()
+      rescue Errno::EPERM => e
+        @logger.warn("Can't move file #{derby_log} due to access permissions")
+      rescue e
+        @logger.warn("Can't move file #{derby_log}", {message => e.message})
+      end
+    end
+
     # later, when local persistent databases are allowed set this property to LS_HOME/data/jdbc-static/
     # must take multi-pipelines into account and more than one config using the same jdbc-static settings
     path_data = Pathname.new(@settings.get_value("path.data")).join("plugins", "filter", "jdbc_static")

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -179,11 +179,11 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
     derby_log = "#{ENV['HOME']}/derby.log"
     if ::File.exist?(derby_log)
       begin
-        ::File.delete()
+        ::File.delete(derby_log)
       rescue Errno::EPERM => e
-        @logger.warn("Can't delete file #{derby_log} due to access permissions")
+        @logger.warn("Can't delete temporary file #{derby_log} due to access permissions")
       rescue e
-        @logger.warn("Can't delete file #{derby_log}", {message => e.message})
+        @logger.warn("Can't delete temporary file #{derby_log}", {message => e.message})
       end
     end
 

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -179,7 +179,7 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
   def prepare_data_dir
     # cleanup existing Derby file left behind in $HOME
     derby_log = "#{ENV['HOME']}/derby.log"
-    if (::File.exist?(derby_log))
+    if ::File.exist?(derby_log)
       begin
         ::File.delete()
       rescue Errno::EPERM => e

--- a/lib/logstash/filters/jdbc_static.rb
+++ b/lib/logstash/filters/jdbc_static.rb
@@ -177,7 +177,9 @@ module LogStash module Filters class JdbcStatic < LogStash::Filters::Base
   def prepare_data_dir
     # later, when local persistent databases are allowed set this property to LS_HOME/data/jdbc-static/
     # must take multi-pipelines into account and more than one config using the same jdbc-static settings
-    java.lang.System.setProperty("derby.system.home", ENV["HOME"])
+    path_data = Pathname.new(settings.get_value("path.data")).join("plugins", "filter", "jdbc_static")
+    path_data.mkpath
+    java.lang.System.setProperty("derby.system.home", path_data.to_path)
     logger.info("derby.system.home is: #{java.lang.System.getProperty("derby.system.home")}")
   end
 

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -243,19 +243,19 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
     # won't in older versions of Logstash, then we need to set it to nil.
     settings = defined?(LogStash::SETTINGS) ? LogStash::SETTINGS : nil
 
-    if record_last_run
-      if last_run_metadata_path.nil?
+    if @record_last_run
+      if l@ast_run_metadata_path.nil?
         logstash_data_path = settings.get_value("path.data")
-        tmp_path = Pathname.new(logstash_data_path).join("plugins", "inputs", "jdbc")
+        logstash_data_path = Pathname.new(logstash_data_path).join("plugins", "inputs", "jdbc")
         # Ensure that the filepath exists before writing, since it's deeply nested.
-        tmp_path.mkpath
-        @last_run_metadata_file_path = tmp_path.join("logstash_jdbc_last_run").to_path
+        logstash_data_path.mkpath
+        @last_run_metadata_file_path = logstash_data_path.join("logstash_jdbc_last_run").to_path
       else
         #  validate the path is a file and not a directory
-        if Pathname.new(last_run_metadata_path).directory?
+        if Pathname.new(@last_run_metadata_path).directory?
           raise ArgumentError.new("The \"last_run_metadata_path\" argument must point to a file, received a directory: \"#{last_run_metadata_path}\"")
         end
-        @last_run_metadata_file_path = last_run_metadata_path
+        @last_run_metadata_file_path = @last_run_metadata_path
       end
     end
 

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -240,13 +240,9 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
   def register
     @logger = self.logger
 
-    # This check is Logstash 5 specific.  If the class does not exist, and it
-    # won't in older versions of Logstash, then we need to set it to nil.
-    settings = defined?(LogStash::SETTINGS) ? LogStash::SETTINGS : nil
-
     if @record_last_run
       if @last_run_metadata_path.nil?
-        logstash_data_path = settings.get_value("path.data")
+        logstash_data_path = LogStash::SETTINGS.get_value("path.data")
         logstash_data_path = Pathname.new(logstash_data_path).join("plugins", "inputs", "jdbc")
         # Ensure that the filepath exists before writing, since it's deeply nested.
         logstash_data_path.mkpath

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -239,6 +239,10 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
   def register
     @logger = self.logger
 
+    # This check is Logstash 5 specific.  If the class does not exist, and it
+    # won't in older versions of Logstash, then we need to set it to nil.
+    settings = defined?(LogStash::SETTINGS) ? LogStash::SETTINGS : nil
+
     if record_last_run
       if last_run_metadata_path.nil?
         logstash_data_path = settings.get_value("path.data")

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -244,7 +244,7 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
     settings = defined?(LogStash::SETTINGS) ? LogStash::SETTINGS : nil
 
     if @record_last_run
-      if l@ast_run_metadata_path.nil?
+      if @last_run_metadata_path.nil?
         logstash_data_path = settings.get_value("path.data")
         logstash_data_path = Pathname.new(logstash_data_path).join("plugins", "inputs", "jdbc")
         # Ensure that the filepath exists before writing, since it's deeply nested.
@@ -253,7 +253,7 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
       else
         #  validate the path is a file and not a directory
         if Pathname.new(@last_run_metadata_path).directory?
-          raise ArgumentError.new("The \"last_run_metadata_path\" argument must point to a file, received a directory: \"#{last_run_metadata_path}\"")
+          raise LogStash::ConfigurationError.new("The \"last_run_metadata_path\" argument must point to a file, received a directory: \"#{last_run_metadata_path}\"")
         end
         @last_run_metadata_file_path = @last_run_metadata_path
       end

--- a/lib/logstash/plugin_mixins/jdbc/value_tracking.rb
+++ b/lib/logstash/plugin_mixins/jdbc/value_tracking.rb
@@ -5,7 +5,7 @@ module LogStash module PluginMixins module Jdbc
   class ValueTracking
 
     def self.build_last_value_tracker(plugin)
-      handler = plugin.record_last_run ? FileHandler.new(plugin.last_run_metadata_path) : NullFileHandler.new(plugin.last_run_metadata_path)
+      handler = plugin.record_last_run ? FileHandler.new(plugin.last_run_metadata_file_path) : NullFileHandler.new(plugin.last_run_metadata_file_path)
       if plugin.clean_run
         handler.clean
       end

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.2.5'
+  s.version         = '5.2.6'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/jdbc_static_spec.rb
+++ b/spec/filters/jdbc_static_spec.rb
@@ -90,7 +90,7 @@ module LogStash module Filters
       it "should be set into Logstash data path" do
         plugin.register
 
-        expected = Pathname.new(LogStash::SETTINGS.get_value("path.data")).join("plugins", "filter", "jdbc_static").to_path
+        expected = Pathname.new(LogStash::SETTINGS.get_value("path.data")).join("plugins", "shared", "derby_home").to_path
         expect(java.lang.System.getProperty("derby.system.home")).to eq(expected)
       end
     end

--- a/spec/filters/jdbc_static_spec.rb
+++ b/spec/filters/jdbc_static_spec.rb
@@ -5,6 +5,7 @@ require "sequel"
 require "sequel/adapters/jdbc"
 require "stud/temporary"
 require "timecop"
+require "pathname"
 
 # LogStash::Logging::Logger::configure_logging("WARN")
 
@@ -84,6 +85,15 @@ module LogStash module Filters
     let(:event)      { ::LogStash::Event.new("message" => "some text", "ip" => ipaddr) }
 
     let(:ipaddr) { ".3.1.1" }
+
+    describe "verify derby path property" do
+      it "should be set into Logstash data path" do
+        plugin.register
+
+        expected = Pathname.new(LogStash::SETTINGS.get_value("path.data")).join("plugins", "filter", "jdbc_static").to_path
+        expect(java.lang.System.getProperty("derby.system.home")).to eq(expected)
+      end
+    end
 
     describe "non scheduled operation" do
       after { plugin.close }

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1181,7 +1181,7 @@ describe LogStash::Inputs::Jdbc do
     context "when a file exists" do
       before do
         # in a faked HOME folder save a valid previous last_run metadata file
-        ENV['HOME'] = fake_home
+        allow(ENV).to receive(:[]).with('HOME').and_return(fake_home)
         File.open("#{ENV['HOME']}/.logstash_jdbc_last_run", 'w') do |file|
           file.write("--- !ruby/object:DateTime '2022-03-08 08:10:00.486889000 Z'")
         end

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -52,6 +52,9 @@ describe LogStash::Inputs::Jdbc do
       db.drop_table(:types_table)
       db.drop_table(:test1_table)
     end
+
+    last_run_default_path = LogStash::SETTINGS.get_value("path.data")
+    FileUtils.rm_f("#{last_run_default_path}/plugins/inputs/jdbc/logstash_jdbc_last_run")
   end
 
   context "when registering and tearing down" do
@@ -1180,7 +1183,7 @@ describe LogStash::Inputs::Jdbc do
         # in a faked HOME folder save a valid previous last_run metadata file
         ENV['HOME'] = fake_home
         File.open("#{ENV['HOME']}/.logstash_jdbc_last_run", 'w') do |file|
-            file.write("--- !ruby/object:DateTime '2022-03-08 08:10:00.486889000 Z'")
+          file.write("--- !ruby/object:DateTime '2022-03-08 08:10:00.486889000 Z'")
         end
       end
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Change default path of 'last_run_metadata_path' to be rooted in the LS `data.path` folder and not in  $HOME. Also apply a path forward action to move existing metadata file to the new destination.

## What does this PR do?

Change default path of 'last_run_metadata_path' to be rooted in the LS data.path folder and not in  $HOME, in the input plugin.
Provide a path forward for existing metada file in `$HOME` to be moved in the new `data.path` destination.

Updates the path used by derby inside the jdbc_static filter plugin to use Logstash `data.path` subfolder.

## Why is it important/What is the impact to the user?

It avoid to store state data into path that Logstash process doesn't have the rights to access.
After PR https://github.com/elastic/logstash/pull/12782, released with Logstash `7.13.0` , the owner of Logstash installation dir changed from `logstash` user to `root`, so the $HOME directory used by Logstash process is not  writable by it.
The process must store data only in the `data.path` folder. 
There's the expectation to create the smoothest path forward, so that users doesn't need to manually update their pipelines nor to manually intervene in moving files on their machines.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

As a user that uses the `record_last_run` I want to be able to upgrade to Logstash >= 7.13 without any throubles about access rights on internal storage files.

