### PR TITLE
Test: adjust logged message assert (due JRuby 9.3)

### DIFF
--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1717,7 +1717,7 @@ describe LogStash::Inputs::Jdbc do
       let(:jdbc_driver_class) { "org.apache.NonExistentDriver" }
       it "raises a loading error" do
         expect { plugin.send(:load_driver) }.to raise_error LogStash::PluginLoadingError,
-                                                            /java.lang.ClassNotFoundException: org.apache.NonExistentDriver/
+                                                            /ClassNotFoundException: org.apache.NonExistentDriver/
       end
     end
   end


### PR DESCRIPTION
```
logstash_1_de98f8ca14c4 |        expected LogStash::PluginLoadingError with message matching /java.lang.ClassNotFoundException: org.apache.NonExistentDriver/, got #<LogStash::PluginLoadingError: #<Java::JavaLang::ClassNotFoundException: org.apache.NonExistentDrive...library is not set, are you sure you included the proper driver client libraries in your classpath?> with backtrace:
logstash_1_de98f8ca14c4 |          # ./lib/logstash/plugin_mixins/jdbc/common.rb:45:in `load_driver'
logstash_1_de98f8ca14c4 |          # ./spec/inputs/jdbc_spec.rb:1707:in `block in <main>'
logstash_1_de98f8ca14c4 |          # ./spec/inputs/jdbc_spec.rb:1707:in `block in <main>'
```
