### PR TITLE
Fix race condition caused by non-unique local table filename

### DIFF
--- a/lib/logstash/filters/jdbc/read_write_database.rb
+++ b/lib/logstash/filters/jdbc/read_write_database.rb
@@ -70,7 +70,7 @@ module LogStash module Filters module Jdbc
         return if records_size.zero?
         logger.info("loader #{loader.id}, fetched #{records_size} records in: #{(Time.now.to_f - start).round(3)} seconds")
         start = Time.now.to_f
-        import_file = ::File.join(loader.staging_directory, SecureRandom.hex(8))
+        import_file = ::File.join(loader.staging_directory, "#{loader.table.to_s}_#{SecureRandom.hex(8)}")
         ::File.open(import_file, "w") do |fd|
           dataset = @db[loader.table]
           records.each do |hash|

--- a/lib/logstash/filters/jdbc/read_write_database.rb
+++ b/lib/logstash/filters/jdbc/read_write_database.rb
@@ -70,7 +70,7 @@ module LogStash module Filters module Jdbc
         return if records_size.zero?
         logger.info("loader #{loader.id}, fetched #{records_size} records in: #{(Time.now.to_f - start).round(3)} seconds")
         start = Time.now.to_f
-        import_file = ::File.join(loader.staging_directory, loader.table.to_s)
+        import_file = ::File.join(loader.staging_directory, SecureRandom.hex(8))
         ::File.open(import_file, "w") do |fd|
           dataset = @db[loader.table]
           records.each do |hash|


### PR DESCRIPTION
Hi, i noticed that when running `jdbc_static` on multiple pipelines, you cannot declare multiple local tables with the same name
unlike stated in the [documentation](https://www.elastic.co/guide/en/logstash/current/plugins-filters-jdbc_static.html#_using_this_plugin_with_multiple_pipelines). 

This fix is meant to solve the issue by uniquely naming the file from which the data is loaded in the local tables.