### PR TITLE
Switch pattern of usage Sequel to leverage the DB connection pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.4.1
+  - Bugfix leak which happened in creating a new Database pool for every query. The pool is now crated on registration and closed on plugin's `stop` [#119](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/119)
+ 
 ## 5.4.0
   - Ambiguous Timestamp Support [#92](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/92)
     - FIX: when encountering an ambiguous timestamp, the JDBC Input no longer crashes

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -261,8 +261,6 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
       end
     end
 
-    prepare_jdbc_connection
-
     if @use_column_value
       # Raise an error if @use_column_value is true, but no @tracking_column is set
       if @tracking_column.nil?
@@ -305,6 +303,20 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
         converters[encoding] = converter
       end
     end
+
+    load_driver
+    begin
+      open_jdbc_connection
+    rescue Sequel::DatabaseConnectionError,
+           Sequel::DatabaseError,
+           Sequel::InvalidValue,
+           Java::JavaSql::SQLException => e
+      details = { exception: e.class, message: e.message }
+      details[:cause] = e.cause.inspect if e.cause
+      details[:backtrace] = e.backtrace if @logger.debug?
+      @logger.warn("Exception when executing JDBC query", details)
+      raise(LogStash::ConfigurationError, "Can't create a connection pool to the database")
+    end
   end # def register
 
   # test injection points
@@ -317,7 +329,6 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
   end
 
   def run(queue)
-    load_driver
     if @schedule
       # scheduler input thread name example: "[my-oracle]|input|jdbc|scheduler"
       scheduler.cron(@schedule) { execute_query(queue) }

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -153,7 +153,7 @@ module LogStash  module PluginMixins module Jdbc
 
     def open_jdbc_connection
       # at this point driver is already loaded
-      ::Sequel.application_timezone = @plugin_timezone.to_sym
+      Sequel.application_timezone = @plugin_timezone.to_sym
 
       @database = jdbc_connect()
       @database.extension(:pagination)

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.4.0'
+  s.version         = '5.4.1'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/integration/integ_spec.rb
+++ b/spec/inputs/integration/integ_spec.rb
@@ -76,10 +76,8 @@ describe LogStash::Inputs::Jdbc, :integration => true do
     end
 
     it "should not register correctly" do
-      plugin.register
-      q = Queue.new
       expect do
-        plugin.run(q)
+        plugin.register
       end.to raise_error(::LogStash::PluginLoadingError)
     end
   end
@@ -92,16 +90,13 @@ describe LogStash::Inputs::Jdbc, :integration => true do
     end
 
     it "log warning msg when plugin run" do
-      plugin.register
       expect( plugin ).to receive(:log_java_exception)
       expect(plugin.logger).to receive(:warn).once.with("Exception when executing JDBC query",
                                                         hash_including(:message => instance_of(String)))
-      q = Queue.new
-      expect{ plugin.run(q) }.not_to raise_error
+      expect{ plugin.register }.to raise_error(::LogStash::ConfigurationError)
     end
 
     it "should log (native) Java driver error" do
-      plugin.register
       expect( org.apache.logging.log4j.LogManager ).to receive(:getLogger).and_wrap_original do |m, *args|
         logger = m.call(*args)
         expect( logger ).to receive(:error) do |_, e|
@@ -109,8 +104,7 @@ describe LogStash::Inputs::Jdbc, :integration => true do
         end.and_call_original
         logger
       end
-      q = Queue.new
-      expect{ plugin.run(q) }.not_to raise_error
+      expect{ plugin.register }.to raise_error(::LogStash::ConfigurationError)
     end
   end
 end

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1565,16 +1565,12 @@ describe LogStash::Inputs::Jdbc do
       { "statement" => "SELECT * from types_table", "jdbc_driver_library" => invalid_driver_jar_path }
     end
 
-    before do
-      plugin.register
-    end
-
     after do
       plugin.stop
     end
 
     it "raise a loading error" do
-      expect { plugin.run(queue) }.
+      expect { plugin.register }.
           to raise_error(LogStash::PluginLoadingError, /unable to load .*? from :jdbc_driver_library, file not readable/)
     end
   end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Bugfix leak which happened in creating a new Database pool for every query. The pool is now crated on registration and closed on plugin's `stop`.

## What does this PR do?

This commit changes the way JDBC input plugin uses the Sequel DB access library. Instead of instantiating a new pool for every query, it creates the pool during registration of the plugin, then reuse that for every DB access. This avoid the connection leaked happening in scheduled queries, as described in #118.

In particular this PR does:
- moved the creation of Sequel Database from `execute_query()` method to plugin's `register`
- removed the reentrant lock that serialized access to the DB. Every DB connection access (creation, query & close) operations was guarded by this lock, which is not clear why existed due to the facts that `Database` is a connection pool per se and is thread safe.
- the close of the `Database` instance now happens only in the plugin's `#stop()` method, which was already present.

## Why is it important/What is the impact to the user?

With certain drivers, when using scheduled queries and reloading the pipeline, it produces a connection leak documented in #118.
The restart of the pipeline was important, because triggered the re-creation of internal plugin structures, like `PreparedStatementHandler` which is responsible for prepared statement re-assignmend accross multiple `Database` instances.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Run as described in the originating issue #118 

## How to test this PR locally

Follow the steps described in #118 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #118 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
