### PR TITLE
Updates for JRuby 9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.4.4
+  - Fix: adaptations for JRuby 9.4 [#125](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/125)
+
 ## 5.4.3
   - Fix crash when metadata file can't be deleted after moving under path.data [#136](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/136)
 

--- a/lib/logstash/plugin_mixins/jdbc/value_tracking.rb
+++ b/lib/logstash/plugin_mixins/jdbc/value_tracking.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 require "yaml" # persistence
+require "date"
+require "bigdecimal"
 
 module LogStash module PluginMixins module Jdbc
   class ValueTracking
@@ -32,7 +34,7 @@ module LogStash module PluginMixins module Jdbc
     end
 
     if Psych::VERSION&.split('.')&.first.to_i >= 4
-      YAML_PERMITTED_CLASSES = [DateTime, Time, BigDecimal].freeze
+      YAML_PERMITTED_CLASSES = [::DateTime, ::Time, ::BigDecimal].freeze
       def self.load_yaml(source)
         Psych::safe_load(source, permitted_classes: YAML_PERMITTED_CLASSES)
       end

--- a/lib/logstash/plugin_mixins/jdbc/value_tracking.rb
+++ b/lib/logstash/plugin_mixins/jdbc/value_tracking.rb
@@ -112,7 +112,7 @@ module LogStash module PluginMixins module Jdbc
 
     def read
       return unless @exists
-      YAML.load(::File.read(@path))
+      YAML.load(::File.read(@path), permitted_classes: [DateTime, Time, BigDecimal])
     end
 
     def write(value)

--- a/lib/logstash/plugin_mixins/jdbc/value_tracking.rb
+++ b/lib/logstash/plugin_mixins/jdbc/value_tracking.rb
@@ -112,7 +112,7 @@ module LogStash module PluginMixins module Jdbc
 
     def read
       return unless @exists
-      YAML.load(::File.read(@path), permitted_classes: [DateTime, Time, BigDecimal])
+      YAML.unsafe_load(::File.read(@path))
     end
 
     def write(value)

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'sequel'
   s.add_runtime_dependency 'lru_redux' # lru cache with ttl
-  s.add_runtime_dependency 'psych', '~> 4'
+  s.add_runtime_dependency 'psych', '~> 4' # required to run on Logstash 7.x and [8.0..8.4)
 
   s.add_runtime_dependency 'tzinfo'
   s.add_runtime_dependency 'tzinfo-data'

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'sequel'
   s.add_runtime_dependency 'lru_redux' # lru cache with ttl
-  s.add_runtime_dependency 'psych', '~> 4' # required to run on Logstash 7.x and [8.0..8.4)
 
   s.add_runtime_dependency 'tzinfo'
   s.add_runtime_dependency 'tzinfo-data'

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'sequel'
   s.add_runtime_dependency 'lru_redux' # lru cache with ttl
+  s.add_runtime_dependency 'psych', '~> 4'
 
   s.add_runtime_dependency 'tzinfo'
   s.add_runtime_dependency 'tzinfo-data'

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.4.3'
+  s.version         = '5.4.4'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/jdbc_streaming_spec.rb
+++ b/spec/filters/jdbc_streaming_spec.rb
@@ -259,7 +259,7 @@ module LogStash module Filters
       CONFIG
       end
 
-      sample("message" => "some text") do
+      sample({"message" => "some text"}) do
         expect(subject.get('new_field')).to eq([{"1" => 'from_database'}])
       end
     end
@@ -277,7 +277,7 @@ module LogStash module Filters
       CONFIG
       end
 
-      sample("message" => "some text") do
+      sample({"message" => "some text"}) do
         expect(subject.get('new_field')).to eq([{"col_1" => 'from_database'}])
       end
     end
@@ -296,11 +296,11 @@ module LogStash module Filters
       CONFIG
       end
 
-      sample("message" => "some text", "param_field" => "1") do
+      sample({"message" => "some text", "param_field" => "1"}) do
         expect(subject.get('new_field')).to eq([{"1" => 'from_database'}])
       end
 
-      sample("message" => "some text", "param_field" => "2") do
+      sample({"message" => "some text", "param_field" => "2"}) do
         expect(subject.get('new_field').nil?)
       end
     end
@@ -319,11 +319,11 @@ module LogStash module Filters
       CONFIG
       end
 
-      sample("message" => "some text", "param_field" => 1) do
+      sample({"message" => "some text", "param_field" => 1}) do
         expect(subject.get('new_field')).to eq([{"1" => 'from_database'}])
       end
 
-      sample("message" => "some text", "param_field" => "1") do
+      sample({"message" => "some text", "param_field" => "1"}) do
         expect(subject.get('new_field').nil?)
       end
     end
@@ -342,7 +342,7 @@ module LogStash module Filters
       CONFIG
       end
 
-      sample("message" => "some text") do
+      sample({"message" => "some text"}) do
         expect(subject.get('new_field')).to eq([{"1" => 'from_database'}])
       end
     end

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1169,7 +1169,7 @@ describe LogStash::Inputs::Jdbc do
     context "when a file exists" do
       before do
         # in a faked HOME folder save a valid previous last_run metadata file
-        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with(anything).and_call_original
         allow(ENV).to receive(:[]).with('HOME').and_return(fake_home)
 
         File.open("#{fake_home}/.logstash_jdbc_last_run", 'w') do |file|

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -277,7 +277,7 @@ describe LogStash::Inputs::Jdbc do
       sleep 1
       for i in 0..1
         sleep 1
-        updated_last_run = YAML.load(File.read(settings["last_run_metadata_path"]), permitted_classes: [Time])
+        updated_last_run = YAML.unsafe_load(File.read(settings["last_run_metadata_path"]))
         expect(updated_last_run).to be > last_run_time
         last_run_time = updated_last_run
       end
@@ -547,7 +547,7 @@ describe LogStash::Inputs::Jdbc do
         expect(actual).to eq(expected)
         plugin.stop
         raw_last_run_value = File.read(settings["last_run_metadata_path"])
-        last_run_value = YAML.load(raw_last_run_value, permitted_classes: [DateTime, Time])
+        last_run_value = YAML.unsafe_load(raw_last_run_value)
         expect(last_run_value).to be_a(DateTime)
         expect(last_run_value.strftime("%F %T.%N %Z")).to eq("2015-01-02 02:00:00.722000000 +00:00")
 
@@ -562,7 +562,7 @@ describe LogStash::Inputs::Jdbc do
         plugin.stop
         expect(event.get("num")).to eq(12)
         expect(event.get("custom_time").time).to eq(Time.iso8601("2015-01-02T03:00:00.811Z"))
-        last_run_value = YAML.load(File.read(settings["last_run_metadata_path"]), permitted_classes: [DateTime, Time])
+        last_run_value = YAML.unsafe_load(File.read(settings["last_run_metadata_path"]))
         expect(last_run_value).to be_a(DateTime)
         # verify that sub-seconds are recorded to the file
         expect(last_run_value.strftime("%F %T.%N %Z")).to eq("2015-01-02 03:00:00.811000000 +00:00")
@@ -1722,7 +1722,7 @@ describe LogStash::Inputs::Jdbc do
           plugin.run(queue)
 
           expect(queue.size).to eq(expected_queue_size)
-          expect(YAML.load(File.read(settings["last_run_metadata_path"]))).to eq(expected_queue_size)
+          expect(YAML.unsafe_load(File.read(settings["last_run_metadata_path"]))).to eq(expected_queue_size)
         end
       end
 
@@ -1747,7 +1747,7 @@ describe LogStash::Inputs::Jdbc do
           plugin.run(queue)
 
           expect(queue.size).to eq(expected_queue_size)
-          expect(YAML.load(File.read(settings["last_run_metadata_path"]))).to eq(last_run_value + expected_queue_size)
+          expect(YAML.unsafe_load(File.read(settings["last_run_metadata_path"]))).to eq(last_run_value + expected_queue_size)
         end
       end
     end

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -277,7 +277,7 @@ describe LogStash::Inputs::Jdbc do
       sleep 1
       for i in 0..1
         sleep 1
-        updated_last_run = YAML.unsafe_load(File.read(settings["last_run_metadata_path"]))
+        updated_last_run = LogStash::PluginMixins::Jdbc::ValueTracking.load_yaml(File.read(settings["last_run_metadata_path"]))
         expect(updated_last_run).to be > last_run_time
         last_run_time = updated_last_run
       end
@@ -547,7 +547,7 @@ describe LogStash::Inputs::Jdbc do
         expect(actual).to eq(expected)
         plugin.stop
         raw_last_run_value = File.read(settings["last_run_metadata_path"])
-        last_run_value = YAML.unsafe_load(raw_last_run_value)
+        last_run_value = LogStash::PluginMixins::Jdbc::ValueTracking.load_yaml(raw_last_run_value)
         expect(last_run_value).to be_a(DateTime)
         expect(last_run_value.strftime("%F %T.%N %Z")).to eq("2015-01-02 02:00:00.722000000 +00:00")
 
@@ -562,7 +562,7 @@ describe LogStash::Inputs::Jdbc do
         plugin.stop
         expect(event.get("num")).to eq(12)
         expect(event.get("custom_time").time).to eq(Time.iso8601("2015-01-02T03:00:00.811Z"))
-        last_run_value = YAML.unsafe_load(File.read(settings["last_run_metadata_path"]))
+        last_run_value = LogStash::PluginMixins::Jdbc::ValueTracking.load_yaml(File.read(settings["last_run_metadata_path"]))
         expect(last_run_value).to be_a(DateTime)
         # verify that sub-seconds are recorded to the file
         expect(last_run_value.strftime("%F %T.%N %Z")).to eq("2015-01-02 03:00:00.811000000 +00:00")
@@ -1722,7 +1722,7 @@ describe LogStash::Inputs::Jdbc do
           plugin.run(queue)
 
           expect(queue.size).to eq(expected_queue_size)
-          expect(YAML.unsafe_load(File.read(settings["last_run_metadata_path"]))).to eq(expected_queue_size)
+          expect(LogStash::PluginMixins::Jdbc::ValueTracking.load_yaml(File.read(settings["last_run_metadata_path"]))).to eq(expected_queue_size)
         end
       end
 
@@ -1747,7 +1747,7 @@ describe LogStash::Inputs::Jdbc do
           plugin.run(queue)
 
           expect(queue.size).to eq(expected_queue_size)
-          expect(YAML.unsafe_load(File.read(settings["last_run_metadata_path"]))).to eq(last_run_value + expected_queue_size)
+          expect(LogStash::PluginMixins::Jdbc::ValueTracking.load_yaml(File.read(settings["last_run_metadata_path"]))).to eq(last_run_value + expected_queue_size)
         end
       end
     end

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -277,7 +277,7 @@ describe LogStash::Inputs::Jdbc do
       sleep 1
       for i in 0..1
         sleep 1
-        updated_last_run = YAML.load(File.read(settings["last_run_metadata_path"]))
+        updated_last_run = YAML.load(File.read(settings["last_run_metadata_path"]), permitted_classes: [Time])
         expect(updated_last_run).to be > last_run_time
         last_run_time = updated_last_run
       end
@@ -547,7 +547,7 @@ describe LogStash::Inputs::Jdbc do
         expect(actual).to eq(expected)
         plugin.stop
         raw_last_run_value = File.read(settings["last_run_metadata_path"])
-        last_run_value = YAML.load(raw_last_run_value)
+        last_run_value = YAML.load(raw_last_run_value, permitted_classes: [DateTime, Time])
         expect(last_run_value).to be_a(DateTime)
         expect(last_run_value.strftime("%F %T.%N %Z")).to eq("2015-01-02 02:00:00.722000000 +00:00")
 
@@ -562,7 +562,7 @@ describe LogStash::Inputs::Jdbc do
         plugin.stop
         expect(event.get("num")).to eq(12)
         expect(event.get("custom_time").time).to eq(Time.iso8601("2015-01-02T03:00:00.811Z"))
-        last_run_value = YAML.load(File.read(settings["last_run_metadata_path"]))
+        last_run_value = YAML.load(File.read(settings["last_run_metadata_path"]), permitted_classes: [DateTime, Time])
         expect(last_run_value).to be_a(DateTime)
         # verify that sub-seconds are recorded to the file
         expect(last_run_value.strftime("%F %T.%N %Z")).to eq("2015-01-02 03:00:00.811000000 +00:00")

--- a/spec/plugin_mixins/jdbc/value_tracking_spec.rb
+++ b/spec/plugin_mixins/jdbc/value_tracking_spec.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+require "logstash/plugin_mixins/jdbc/value_tracking"
+
+module LogStash module PluginMixins module Jdbc
+  describe ValueTracking do
+
+    let(:yaml_date_source) { "--- !ruby/object:DateTime '2023-06-15 09:59:30.558000000 +02:00'\n" }
+
+    context "#load_yaml" do
+      it "should load yaml with date string" do
+        parsed_date = LogStash::PluginMixins::Jdbc::ValueTracking.load_yaml(yaml_date_source)
+        expect(parsed_date.year).to eq 2023
+        expect(parsed_date.month).to eq 6
+        expect(parsed_date.day).to eq 15
+      end
+    end
+  end
+end end end

--- a/spec/plugin_mixins/jdbc/value_tracking_spec.rb
+++ b/spec/plugin_mixins/jdbc/value_tracking_spec.rb
@@ -3,15 +3,43 @@ require "logstash/plugin_mixins/jdbc/value_tracking"
 
 module LogStash module PluginMixins module Jdbc
   describe ValueTracking do
-
-    let(:yaml_date_source) { "--- !ruby/object:DateTime '2023-06-15 09:59:30.558000000 +02:00'\n" }
-
     context "#load_yaml" do
-      it "should load yaml with date string" do
-        parsed_date = LogStash::PluginMixins::Jdbc::ValueTracking.load_yaml(yaml_date_source)
-        expect(parsed_date.year).to eq 2023
-        expect(parsed_date.month).to eq 6
-        expect(parsed_date.day).to eq 15
+
+      context "with date string" do
+        let(:yaml_date_source) { "--- !ruby/object:DateTime '2023-06-15 09:59:30.558000000 +02:00'\n" }
+
+        it "should be loaded" do
+          parsed_date = LogStash::PluginMixins::Jdbc::ValueTracking.load_yaml(yaml_date_source)
+          expect(parsed_date.class).to eq DateTime
+          expect(parsed_date.year).to eq 2023
+          expect(parsed_date.month).to eq 6
+          expect(parsed_date.day).to eq 15
+        end
+      end
+
+      context "with time string" do
+        let(:yaml_time_source) { "--- 2023-06-15 15:28:15.227874000 +02:00\n" }
+
+        it "should be loaded" do
+          parsed_time = LogStash::PluginMixins::Jdbc::ValueTracking.load_yaml(yaml_time_source)
+          expect(parsed_time.class).to eq Time
+          expect(parsed_time.year).to eq 2023
+          expect(parsed_time.month).to eq 6
+          expect(parsed_time.day).to eq 15
+          expect(parsed_time.hour).to eq 15
+          expect(parsed_time.min).to eq 28
+          expect(parsed_time.sec).to eq 15
+        end
+      end
+
+      context "with date string" do
+        let(:yaml_bigdecimal_source) { "--- !ruby/object:BigDecimal '0:0.1e1'\n" }
+
+        it "should be loaded" do
+          parsed_bigdecimal = LogStash::PluginMixins::Jdbc::ValueTracking.load_yaml(yaml_bigdecimal_source)
+          expect(parsed_bigdecimal.class).to eq BigDecimal
+          expect(parsed_bigdecimal.to_i).to eq 1
+        end
       end
     end
   end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
Fix: adaptations for JRuby 9.4


## What does this PR do?

This PR laid down adaptations to run this plugin under JRuby 9.4 (Ruby 3.1)

List of changes:
- in a method with var args the hash map has to be defined when passed as argument, d19fc58ab9d0eb1588811e9e43e78f80cefb8903  [Ruby 3.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)
- Ruby 3.1 comes with Psych 4 which switched the alias of `load` from `unsafe_load` to `safe_load`  [reference](https://www.ctrl.blog/entry/ruby-psych4.html). Created a wrapper method to behave consistently across different versions of JRuby.
- fixed a stubbing error in tests: 72a2af524bd56f3d6bb22bfd744d4fb9a5d36a86


## Why is it important/What is the impact to the user?

Let the user to use this plugin also on future Logstash versions which ship JRuby >= 9.4

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run tests locally with JRuby 9.3 against a Logstash with JRuby 9.3
- [x] run tests locally with JRuby 9.4 against a Logstash with JRuby 9.4
- [x] run the plugin on a Logstash that ships JRuby 9.4

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #133 
- https://github.com/elastic/logstash/issues/14996
