### PR TITLE
Session handling reprise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.5.2
+  - FIX: the input plugin's prior behaviour of opening a new database connection for each scheduled run (removed in `v5.4.1`) is restored, ensuring that infrequently-run schedules do not hold open connections to their databases indefinitely, _without_ reintroducing the leak [#130](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/130)
+
 ## 5.5.1
   - Document `statement_retry_attempts` and `statement_retry_attempts_wait_time` options
 

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -305,6 +305,7 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
         converters[encoding] = converter
       end
     end
+    load_driver
   end # def register
 
   # test injection points
@@ -317,7 +318,6 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
   end
 
   def run(queue)
-    load_driver
     if @schedule
       # scheduler input thread name example: "[my-oracle]|input|jdbc|scheduler"
       scheduler.cron(@schedule) { execute_query(queue) }

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -12,6 +12,9 @@ java_import java.util.concurrent.locks.ReentrantLock
 
 # Tentative of abstracting JDBC logic to a mixin
 # for potential reuse in other plugins (input/output)
+#
+# CAUTION: implementation of this "potential reuse" module is
+#          VERY tightly-coupled with the JDBC Input's implementation.
 module LogStash  module PluginMixins module Jdbc
   module Jdbc
     include LogStash::PluginMixins::Jdbc::ValueHandler

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -3,12 +3,11 @@
 require "logstash/config/mixin"
 require "time"
 require "date"
+require "thread" # Monitor
 require_relative "value_tracking"
 require_relative "timezone_proxy"
 require_relative "statement_handler"
 require_relative "value_handler"
-
-java_import java.util.concurrent.locks.ReentrantLock
 
 # Tentative of abstracting JDBC logic to a mixin
 # for potential reuse in other plugins (input/output)
@@ -162,95 +161,94 @@ module LogStash  module PluginMixins module Jdbc
     end
 
     def open_jdbc_connection
-      # at this point driver is already loaded
-      Sequel.application_timezone = @plugin_timezone.to_sym
+      @connection_lock.synchronize do
+        # at this point driver is already loaded
+        Sequel.application_timezone = @plugin_timezone.to_sym
 
-      @database = jdbc_connect()
-      @database.extension(:pagination)
-      if @jdbc_default_timezone
-        @database.extension(:named_timezones)
-        @database.timezone = TimezoneProxy.load(@jdbc_default_timezone)
-      end
-      if @jdbc_validate_connection
-        @database.extension(:connection_validator)
-        @database.pool.connection_validation_timeout = @jdbc_validation_timeout
-      end
-      @database.fetch_size = @jdbc_fetch_size unless @jdbc_fetch_size.nil?
-      begin
-        @database.test_connection
-      rescue Java::JavaSql::SQLException => e
-        @logger.warn("Failed test_connection with java.sql.SQLException.", :exception => e)
-      rescue Sequel::DatabaseConnectionError => e
-        @logger.warn("Failed test_connection.", :exception => e)
-        #TODO return false and let the plugin raise a LogStash::ConfigurationError
-        raise e
-      end
+        @database = jdbc_connect()
+        @database.extension(:pagination)
+        if @jdbc_default_timezone
+          @database.extension(:named_timezones)
+          @database.timezone = TimezoneProxy.load(@jdbc_default_timezone)
+        end
+        if @jdbc_validate_connection
+          @database.extension(:connection_validator)
+          @database.pool.connection_validation_timeout = @jdbc_validation_timeout
+        end
+        @database.fetch_size = @jdbc_fetch_size unless @jdbc_fetch_size.nil?
+        begin
+          @database.test_connection
+        rescue Java::JavaSql::SQLException => e
+          @logger.warn("Failed test_connection with java.sql.SQLException.", :exception => e)
+        rescue Sequel::DatabaseConnectionError => e
+          @logger.warn("Failed test_connection.", :exception => e)
+          #TODO return false and let the plugin raise a LogStash::ConfigurationError
+          raise e
+        end
 
-      @database.sql_log_level = @sql_log_level.to_sym
-      @database.logger = @logger
+        @database.sql_log_level = @sql_log_level.to_sym
+        @database.logger = @logger
 
-      @database.extension :identifier_mangling
+        @database.extension :identifier_mangling
 
-      if @lowercase_column_names
-        @database.identifier_output_method = :downcase
-      else
-        @database.identifier_output_method = :to_s
+        if @lowercase_column_names
+          @database.identifier_output_method = :downcase
+        else
+          @database.identifier_output_method = :to_s
+        end
       end
     end
 
     public
     def prepare_jdbc_connection
-      @connection_lock = ReentrantLock.new
+      @connection_lock = Monitor.new # aka ReentrantLock
     end
 
     public
     def close_jdbc_connection
-      begin
+      @connection_lock.synchronize do
         # pipeline restarts can also close the jdbc connection, block until the current executing statement is finished to avoid leaking connections
         # connections in use won't really get closed
-        @connection_lock.lock
         @database.disconnect if @database
-      rescue => e
-        @logger.warn("Failed to close connection", :exception => e)
-      ensure
-        @connection_lock.unlock
       end
+    rescue => e
+      @logger.warn("Failed to close connection", :exception => e)
     end
 
     public
-    def execute_statement
+    def execute_statement(&result_handler)
       success = false
       retry_attempts = @statement_retry_attempts
 
-      begin
-        retry_attempts -= 1
-        @connection_lock.lock
-        open_jdbc_connection
-        sql_last_value = @use_column_value ? @value_tracker.value : Time.now.utc
-        @tracking_column_warning_sent = false
-        @statement_handler.perform_query(@database, @value_tracker.value) do |row|
-          sql_last_value = get_column_value(row) if @use_column_value
-          yield extract_values_from(row)
-        end
-        success = true
-      rescue Sequel::Error, Java::JavaSql::SQLException => e
-        details = { exception: e.class, message: e.message }
-        details[:cause] = e.cause.inspect if e.cause
-        details[:backtrace] = e.backtrace if @logger.debug?
-        @logger.warn("Exception when executing JDBC query", details)
+      @connection_lock.synchronize do
+        begin
+          retry_attempts -= 1
+          open_jdbc_connection
+          sql_last_value = @use_column_value ? @value_tracker.value : Time.now.utc
+          @tracking_column_warning_sent = false
+          @statement_handler.perform_query(@database, @value_tracker.value) do |row|
+            sql_last_value = get_column_value(row) if @use_column_value
+            yield extract_values_from(row)
+          end
+          success = true
+        rescue Sequel::Error, Java::JavaSql::SQLException => e
+          details = { exception: e.class, message: e.message }
+          details[:cause] = e.cause.inspect if e.cause
+          details[:backtrace] = e.backtrace if @logger.debug?
+          @logger.warn("Exception when executing JDBC query", details)
 
-        if retry_attempts == 0
-          @logger.error("Unable to execute statement. Tried #{@statement_retry_attempts} times.")
+          if retry_attempts == 0
+            @logger.error("Unable to execute statement. Tried #{@statement_retry_attempts} times.")
+          else
+            @logger.error("Unable to execute statement. Trying again.")
+            sleep(@statement_retry_attempts_wait_time)
+            retry
+          end
         else
-          @logger.error("Unable to execute statement. Trying again.")
-          sleep(@statement_retry_attempts_wait_time)
-          retry
+          @value_tracker.set_value(sql_last_value)
+        ensure
+          close_jdbc_connection
         end
-      else
-        @value_tracker.set_value(sql_last_value)
-      ensure
-        close_jdbc_connection
-        @connection_lock.unlock
       end
 
       return success

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.5.1'
+  s.version         = '5.5.2'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/integration/integ_spec.rb
+++ b/spec/inputs/integration/integ_spec.rb
@@ -99,10 +99,8 @@ describe LogStash::Inputs::Jdbc, :integration => true do
     end
 
     it "should not register correctly" do
-      plugin.register
-      q = Queue.new
       expect do
-        plugin.run(q)
+        plugin.register
       end.to raise_error(::LogStash::PluginLoadingError)
     end
   end

--- a/spec/inputs/integration/integ_spec.rb
+++ b/spec/inputs/integration/integ_spec.rb
@@ -99,8 +99,10 @@ describe LogStash::Inputs::Jdbc, :integration => true do
     end
 
     it "should not register correctly" do
+      plugin.register
+      q = Queue.new
       expect do
-        plugin.register
+        plugin.run(q)
       end.to raise_error(::LogStash::PluginLoadingError)
     end
   end
@@ -113,13 +115,16 @@ describe LogStash::Inputs::Jdbc, :integration => true do
     end
 
     it "log warning msg when plugin run" do
+      plugin.register
       expect( plugin ).to receive(:log_java_exception)
       expect(plugin.logger).to receive(:warn).once.with("Exception when executing JDBC query",
                                                         hash_including(:message => instance_of(String)))
-      expect{ plugin.register }.to raise_error(::LogStash::ConfigurationError)
+      q = Queue.new
+      expect{ plugin.run(q) }.not_to raise_error
     end
 
     it "should log (native) Java driver error" do
+      plugin.register
       expect( org.apache.logging.log4j.LogManager ).to receive(:getLogger).and_wrap_original do |m, *args|
         logger = m.call(*args)
         expect( logger ).to receive(:error) do |_, e|
@@ -127,7 +132,8 @@ describe LogStash::Inputs::Jdbc, :integration => true do
         end.and_call_original
         logger
       end
-      expect{ plugin.register }.to raise_error(::LogStash::ConfigurationError)
+      q = Queue.new
+      expect{ plugin.run(q) }.not_to raise_error
     end
   end
 end

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1645,21 +1645,11 @@ describe LogStash::Inputs::Jdbc do
       { "statement" => "SELECT * from types_table", "jdbc_driver_library" => invalid_driver_jar_path }
     end
 
-    before do
-      plugin.register
-    end
-
-    after do
-      plugin.stop
-    end
-
-    it "raise a loading error" do
+    it "raise a loading error during #register" do
       expect(File.exists?(invalid_driver_jar_path)).to be true
       expect(FileTest.readable?(invalid_driver_jar_path)).to be false
 
-      plugin.register
-
-      expect { plugin.run(queue) }
+      expect { plugin.register }
         .to raise_error(LogStash::PluginLoadingError, /unable to load .*? from :jdbc_driver_library, file not readable/)
     end
   end

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1283,6 +1283,7 @@ describe LogStash::Inputs::Jdbc do
       plugin.register
       plugin.run(queue)
       db = plugin.instance_variable_get(:@database)
+      expect(db.pool).to be_a_kind_of(::Sequel::ThreadedConnectionPool) # pries into internal details
       expect(db.pool.instance_variable_get(:@timeout)).to eq(0)
       expect(db.pool.instance_variable_get(:@max_size)).to eq(1)
 


### PR DESCRIPTION
Resolves the [described connection leak in prepared statements](https://github.com/logstash-plugins/logstash-integration-jdbc/issues/118#issuecomment-1290951734) in an alternate way to the solution presented in #119, restoring the prior behavior for the input to make one DB connection per scheduler invocation.


 - in v5.4.0 and before, prepared statement handler leaked connections
 - in v5.4.1 connection moved from run-phase to register, which causes connection issues to prevent pipeline from starting; this is problematic for customers whose pipeline reloads fail because it requires human intervention, and also causes undesired long-lived connections.
 - this PR reverts the v5.4.1 fix, and solves the original issue by refactoring the prepared statement handler to avoid the connection leak

_However_:

 - v5.4.1-fix had an accidentally-desired behavior change, in which unscheduled instances that failed to connect would fail in `register`, which would crash the pipeline.
 - Prior to that fix, failing to connect would fail in `execute_statement`, which would only lead to a log message; when the job was unscheduled, this would lead to the plugin closing normally

Question:

 - when the plugin has no schedule, and cannot connect at startup, is it desirable to continue to crash the plugin (and therefore the pipeline)?