### PR TITLE
Pin sequel to < 5.72.0 due to ruby/bigdecimal#169

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.4.5
+  - Pin sequel to < 5.72.0 due to ruby/bigdecimal#169 [#141](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/141)
+
 ## 5.4.4
   - Fix: adaptations for JRuby 9.4 [#125](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/125)
 

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   # Restrict use of this plugin to versions of Logstash where support for integration plugins is present.
   s.add_runtime_dependency "logstash-core", ">= 6.5.0"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'sequel'
+  s.add_runtime_dependency 'sequel', '< 5.72.0' # until https://github.com/ruby/bigdecimal/issues/169 is fixed
   s.add_runtime_dependency 'lru_redux' # lru cache with ttl
 
   s.add_runtime_dependency 'tzinfo'

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.4.4'
+  s.version         = '5.4.5'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Sequel 5.72.0 explicitly depends on the bigdecimal gem, causing JRuby to attempt to use the gem, install native extensions and fail. Pinning to < 5.72.0 until https://github.com/ruby/bigdecimal/issues/169 is solved.

Also related: https://github.com/jeremyevans/sequel/issues/2076