### PR TITLE
Adds assertions in test to verify read permissions removal on JDBC driver

### DIFF
--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1598,6 +1598,11 @@ describe LogStash::Inputs::Jdbc do
       path = File.join(Dir.mktmpdir, File.basename(driver_jar_path))
       FileUtils.cp driver_jar_path, path
       FileUtils.chmod "u=x,go=", path
+      # verify it's effectively read permissions are dropped
+      perm_bin = File.stat(path).mode.to_s(2)[-9..]
+      expect(perm_bin[0]).to eq("0")
+      expect(perm_bin[3]).to eq("0")
+      expect(perm_bin[6]).to eq("0")
       path
     end
 

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1599,7 +1599,7 @@ describe LogStash::Inputs::Jdbc do
       FileUtils.cp driver_jar_path, path
       FileUtils.chmod "u=x,go=", path
       # verify it's effectively read permissions are dropped
-      perm_bin = File.stat(path).mode.to_s(2)[-9..]
+      perm_bin = File.stat(path).mode.to_s(2)[-9..-1]
       expect(perm_bin[0]).to eq("0")
       expect(perm_bin[3]).to eq("0")
       expect(perm_bin[6]).to eq("0")

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1597,7 +1597,8 @@ describe LogStash::Inputs::Jdbc do
     let(:invalid_driver_jar_path) do
       path = File.join(Dir.mktmpdir, File.basename(driver_jar_path))
       FileUtils.cp driver_jar_path, path
-      FileUtils.chmod "u=x,go=", path
+      num_processed = File.chmod(0100, path)
+      expect(num_processed).to eq(1)
       # verify it's effectively read permissions are dropped
       perm_bin = File.stat(path).mode.to_s(2)[-9..-1]
       expect(perm_bin[0]).to eq("0")


### PR DESCRIPTION
Adds assertions in test to verify read permissions removal after JDBC driver jar is manipulated with `FileUtils.chmod`

