### PR TITLE
Update sequel version to >= 5.74.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.4.7
+  - Update sequel version to >= 5.75.0. It fixes the generic jdbc adapter to properly handle disconnect errors [#153](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/153)
+
 ## 5.4.6
   - Update sequel version to >= 5.73.0. The ibmdb and jdbc/db2 adapters were fixed to properly handle disconnect errors, removing the related connection from the pool [#144](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/144)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.4.7
-  - Update sequel version to >= 5.75.0. It fixes the generic jdbc adapter to properly handle disconnect errors [#153](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/153)
+  - Update sequel version to >= 5.74.0. It fixes the generic jdbc adapter to properly handle disconnect errors [#153](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/153)
 
 ## 5.4.6
   - Update sequel version to >= 5.73.0. The ibmdb and jdbc/db2 adapters were fixed to properly handle disconnect errors, removing the related connection from the pool [#144](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/144)

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.4.6'
+  s.version         = '5.4.7'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   # Restrict use of this plugin to versions of Logstash where support for integration plugins is present.
   s.add_runtime_dependency "logstash-core", ">= 6.5.0"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'sequel', '>= 5.73.0'
+  s.add_runtime_dependency 'sequel', '>= 5.75.0'
   s.add_runtime_dependency 'lru_redux' # lru cache with ttl
 
   s.add_runtime_dependency 'tzinfo'

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |s|
   # Restrict use of this plugin to versions of Logstash where support for integration plugins is present.
   s.add_runtime_dependency "logstash-core", ">= 6.5.0"
   s.add_runtime_dependency 'logstash-codec-plain'
-  # Pinned sequel version to >= 5.75.0 as it fixes the generic jdbc adapter to properly
+  # Pinned sequel version to >= 5.74.0 as it fixes the generic jdbc adapter to properly
   # handle disconnection errors, and avoid stale connections in the pool.
-  s.add_runtime_dependency 'sequel', '>= 5.75.0'
+  s.add_runtime_dependency 'sequel', '>= 5.74.0'
   s.add_runtime_dependency 'lru_redux' # lru cache with ttl
 
   s.add_runtime_dependency 'tzinfo'

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |s|
   # Restrict use of this plugin to versions of Logstash where support for integration plugins is present.
   s.add_runtime_dependency "logstash-core", ">= 6.5.0"
   s.add_runtime_dependency 'logstash-codec-plain'
+  # Pinned sequel version to >= 5.75.0 as it fixes the generic jdbc adapter to properly
+  # handle disconnection errors, and avoid stale connections in the pool.
   s.add_runtime_dependency 'sequel', '>= 5.75.0'
   s.add_runtime_dependency 'lru_redux' # lru cache with ttl
 


### PR DESCRIPTION
Updated the `sequel` gem version to >= [5.74.0](https://sequel.jeremyevans.net/rdoc/files/doc/release_notes/5_74_0_txt.html)

---
Closes: https://github.com/logstash-plugins/logstash-integration-jdbc/issues/152