### PR TITLE
fix: use `Array#<<` to append an element to an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
+## 5.4.11
+- Fixes an exception that could occur while reloading `jdbc_static` databases when the underlying connection to the remote has been broken [#165](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/165)
+
 ## 5.4.10
- - Adds retry mechanism when checkout Derby from SVN repository [#158](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/158)
- - [DOC] add known limitations and settings for connection issue [#167](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/167)
+- Adds retry mechanism when checkout Derby from SVN repository [#158](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/158)
+- [DOC] add known limitations and settings for connection issue [#167](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/167)
 
 ## 5.4.9
   - Fix Derby missed driver classes when built locally for version 10.15 [#160](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/160)

--- a/lib/logstash/filters/jdbc/read_only_database.rb
+++ b/lib/logstash/filters/jdbc/read_only_database.rb
@@ -12,7 +12,7 @@ module LogStash module Filters module Jdbc
         if connected?
           result = @db[statement].count
         else
-          debug_log_messages.concat("and there is no connection to the remote db at this time")
+          debug_log_messages << "and there is no connection to the remote db at this time"
         end
       rescue ::Sequel::Error => err
         # a fatal issue
@@ -32,7 +32,7 @@ module LogStash module Filters module Jdbc
         if connected?
           result = @db[statement].all
         else
-          debug_log_messages.concat("and there is no connection to the remote db at this time")
+          debug_log_messages << "and there is no connection to the remote db at this time"
         end
       rescue ::Sequel::Error => err
         # a fatal issue

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.4.10'
+  s.version         = '5.4.11'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION

Ruby's `Array#concat` needs an _Array_ argument; appending a single element can be done with `Array#<<`.

Fixes exception that could occur repeatedly when the upstream loader is not currently connected:

~~~
TypeError, original message: no 
implicit conversion of String into Array", :backtrace=>["org/jruby/RubyArray.java:1670:in `concat'", 
"/usr/share/logstash/vendor/bundle/jruby/2.6.0/gems/logstash-integration-jdbc-
5.4.1/lib/logstash/filters/jdbc/read_only_database.rb:15:in `count'",
~~~