### PR TITLE
[Doc] clarified the usage of and  settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
- - [DOC] clarified the usage of `jdbc_validation_timeout`and `connection_retry_attempts_wait_time` settings.
+ - [DOC] clarified the usage of `jdbc_validation_timeout` and `connection_retry_attempts_wait_time` settings. [#169](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/169)
 
 ## 5.4.10
  - Adds retry mechanism when checkout Derby from SVN repository [#158](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/158)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+ - [DOC] clarified the usage of `jdbc_validation_timeout`and `connection_retry_attempts_wait_time` settings.
+
 ## 5.4.10
  - Adds retry mechanism when checkout Derby from SVN repository [#158](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/158)
  - [DOC] add known limitations and settings for connection issue [#167](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/167)

--- a/docs/filter-jdbc_streaming.asciidoc
+++ b/docs/filter-jdbc_streaming.asciidoc
@@ -213,6 +213,7 @@ Validate connection before use.
 
 Connection pool configuration.
 How often to validate a connection (in seconds).
+Validation is done only when a connection is borrowed from the pool and not done actively while lays in the pool.
 
 [id="plugins-{type}s-{plugin}-parameters"]
 ===== `parameters`

--- a/docs/input-jdbc.asciidoc
+++ b/docs/input-jdbc.asciidoc
@@ -294,7 +294,7 @@ Maximum number of times to try connecting to database
   * Value type is <<number,number>>
   * Default value is `0.5`
 
-Number of seconds to sleep between connection attempts
+Number of seconds to sleep between connection pool creation attempts. Used only during the registration of the plugin.
 
 [id="plugins-{type}s-{plugin}-jdbc_connection_string"]
 ===== `jdbc_connection_string`
@@ -508,7 +508,8 @@ Validate connection before use.
   * Default value is `3600`
 
 Connection pool configuration.
-How often to validate a connection (in seconds)
+How often to validate a connection (in seconds).
+Validation is done only when a connection is borrowed from the pool and not done actively while lays in the pool.
 
 [id="plugins-{type}s-{plugin}-last_run_metadata_path"]
 ===== `last_run_metadata_path`

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -69,7 +69,8 @@ module LogStash  module PluginMixins module Jdbc
       config :jdbc_validate_connection, :validate => :boolean, :default => false
 
       # Connection pool configuration.
-      # How often to validate a connection (in seconds)
+      # How often to validate a connection (in seconds).
+      # Validation is done only when a connection is borrowed from the pool and not done actively while lays in the pool.
       config :jdbc_validation_timeout, :validate => :number, :default => 3600
 
       # Connection pool configuration.
@@ -101,7 +102,7 @@ module LogStash  module PluginMixins module Jdbc
 
       # Maximum number of times to try connecting to database
       config :connection_retry_attempts, :validate => :number, :default => 1
-      # Number of seconds to sleep between connection attempts
+      # Number of seconds to sleep between connection pool creation attempts. Used only during the registration of the plugin.
       config :connection_retry_attempts_wait_time, :validate => :number, :default => 0.5
 
       # Maximum number of times to try running statement

--- a/lib/logstash/plugin_mixins/jdbc_streaming.rb
+++ b/lib/logstash/plugin_mixins/jdbc_streaming.rb
@@ -51,7 +51,8 @@ module LogStash module PluginMixins module JdbcStreaming
     config :jdbc_validate_connection, :validate => :boolean, :default => false
 
     # Connection pool configuration.
-    # How often to validate a connection (in seconds)
+    # How often to validate a connection (in seconds).
+    # Validation is done only when a connection is borrowed from the pool and not done actively while lays in the pool.
     config :jdbc_validation_timeout, :validate => :number, :default => 3600
   end
 


### PR DESCRIPTION
## Release notes
Clarified the usage of `jdbc_validation_timeout` and `connection_retry_attempts_wait_time` settings.


## What does this PR do?

Improve the documentation description of a couple of configs.
The `connection_retry_attempts_wait_time` is used as retry mechanism only at Sequel Database object creation, so at connection pool time creation, during the registration of the plugin.
The `jdbc_validation_timeout` is used by Sequel to decide to validate or not a connection when it's borrowed from the pool. If the connection hasn't received or sent data for more than this timeout then a "ping query" is executed; but it doesn't actively executes the ping queries when the connections are in the pool, just on the borrow action.

- [code ref](https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.4.6/lib/logstash/plugin_mixins/jdbc/jdbc.rb#L119-L140) to check how `connection_retry_attempts_wait_time` is used
- [code ref](https://github.com/jeremyevans/sequel/blob/5.75.0/lib/sequel/extensions/connection_validator.rb#L108) to check how `jdbc_validation_timeout` is used in Sequel.

## Why is it important/What is the impact to the user?

Avoid to set not aligned expectations on the usage of these settings.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
