### PR TITLE
build: support java 21 vs SecurityManager changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ Gemfile.lock
 .bundle
 vendor
 derby.log
+build
+.ci/
+checkpoint.sha
+.gradle
+.idea

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
 org.gradle.daemon=false
+
+# Configure Ant to WARN (instead of error) when SecurityManager is not available
+systemProp.ant.securitymanager.usage.warn=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Configure ANT to WARN about the SecurityManager instead of producing an error that breaks the build.

Fixes: logstash-plugins/logstash-integration-jdbc#173

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
