### PR TITLE
Support other rufus scheduling options

### DIFF
--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -180,6 +180,20 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
   # exactly once.
   config :schedule, :validate => :string
 
+  # Interval of how soon to run statement again after completion
+  # for example: "1m" (execute again 1 minute after completion)
+  #
+  # There is no interval by default. If no interval is given, then the statement is run
+  # exactly once.
+  config :interval, :validate => :string
+
+  # Start the job periodically after time elapsed
+  # for example: "1m" (execute query every minute)
+  #
+  # There is no period by default. If no period is given, then the statement is run
+  # exactly once.
+  config :period, :validate => :string
+
   # Path to file with last run time.
   # The default will write file to `<path.data>/plugins/inputs/jdbc/logstash_jdbc_last_run`
   # NOTE: it must be a file path and not a directory path
@@ -321,6 +335,12 @@ module LogStash module Inputs class Jdbc < LogStash::Inputs::Base
     if @schedule
       # scheduler input thread name example: "[my-oracle]|input|jdbc|scheduler"
       scheduler.cron(@schedule) { execute_query(queue) }
+      scheduler.join
+    elsif @interval
+      scheduler.interval(@interval) { execute_query(queue) }
+      scheduler.join
+    elsif @period
+      scheduler.every(@period) { execute_query(queue) }
       scheduler.join
     else
       execute_query(queue)


### PR DESCRIPTION
Allow jdbc input to be scheduled with different options supported by rufus scheduler.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
