### PR TITLE
jdbc_static filter: configure connection pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.6.1
+  - Fixes an issue where the `jdbc_static` filter's throughput was artificially limited to 4 concurrent queries, causing the plugin to become a bottleneck in pipelines with more than 4 workers. Each instance of the plugin is now limited to 16 concurrent queries, with increased timeouts to eliminate enrichment failures.
+
 ## 5.6.0
   - Support other rufus scheduling options in JDBC Input [#183](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/183)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.6.1
-  - Fixes an issue where the `jdbc_static` filter's throughput was artificially limited to 4 concurrent queries, causing the plugin to become a bottleneck in pipelines with more than 4 workers. Each instance of the plugin is now limited to 16 concurrent queries, with increased timeouts to eliminate enrichment failures.
+  - Fixes an issue where the `jdbc_static` filter's throughput was artificially limited to 4 concurrent queries, causing the plugin to become a bottleneck in pipelines with more than 4 workers. Each instance of the plugin is now limited to 16 concurrent queries, with increased timeouts to eliminate enrichment failures [#187](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/187)
 
 ## 5.6.0
   - Support other rufus scheduling options in JDBC Input [#183](https://github.com/logstash-plugins/logstash-integration-jdbc/pull/183)

--- a/lib/logstash/filters/jdbc/read_write_database.rb
+++ b/lib/logstash/filters/jdbc/read_write_database.rb
@@ -103,6 +103,11 @@ module LogStash module Filters module Jdbc
       super
       # get a fair reentrant read write lock
       @rwlock = java.util.concurrent.locks.ReentrantReadWriteLock.new(true)
+
+      # configure the connection pool to reduce the chances of
+      # a worker thread being unable to acquire a connection.
+      @options_hash[:max_connections] = 16 # sequel default: 4
+      @options_hash[:pool_timeout] = 30    # sequel default: 5
     end
   end
 end end end

--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-integration-jdbc'
-  s.version         = '5.6.0'
+  s.version         = '5.6.1'
   s.licenses = ['Apache License (2.0)']
   s.summary         = "Integration with JDBC - input and filter plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
By increasing the size of the connection pool from the Sequel-default 4 to 16, we increase the max parallelism of pipelines that are using this filter by four- fold, reducing the situations where a pipeline's total throughput is constrained by this plugin's connection pool to the internal Derby DB.

We also increase the pool timeout from the Sequel-default 5 seconds to 30 seconds, so that failures to immediately acquire a connection don't result in failed lookups.

This issue is meant to mitigate the root-cause beneath https://github.com/logstash-plugins/logstash-integration-jdbc/issues/186 _without_ expanding the scope of configuration options for the `jdbc_static` filter, which would be a substantial effort.