### PR TITLE
Fix case of `VERSION` to `version` in gemspec

### DIFF
--- a/logstash-integration-jdbc.gemspec
+++ b/logstash-integration-jdbc.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths   = ["lib", "vendor/jar-dependencies"]
 
   # Files
-  s.files = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb", "VERSION", "docs/**/*"]
+  s.files = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb", "version", "docs/**/*"]
 
    # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Fix case of `VERSION` to `version` in gemspec