### PR TITLE
Fix connection leak on statement retry by opening JDBC connection once outside retry loop

### DIFF
--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -160,6 +160,13 @@ module LogStash  module PluginMixins module Jdbc
       logger.error('', e) # prints nested causes
     end
 
+    def log_jdbc_query_exception(e)
+      details = { exception: e.class, message: e.message }
+      details[:cause] = e.cause.inspect if e.cause
+      details[:backtrace] = e.backtrace if @logger.debug?
+      @logger.warn("Exception when executing JDBC query", details)
+    end
+
     def open_jdbc_connection
       @connection_lock.synchronize do
         # at this point driver is already loaded
@@ -233,10 +240,7 @@ module LogStash  module PluginMixins module Jdbc
             end
             success = true
           rescue Sequel::Error, Java::JavaSql::SQLException => e
-            details = { exception: e.class, message: e.message }
-            details[:cause] = e.cause.inspect if e.cause
-            details[:backtrace] = e.backtrace if @logger.debug?
-            @logger.warn("Exception when executing JDBC query", details)
+            log_jdbc_query_exception(e)
 
             if retry_attempts == 0
               @logger.error("Unable to execute statement. Tried #{@statement_retry_attempts} times.")
@@ -249,8 +253,7 @@ module LogStash  module PluginMixins module Jdbc
             @value_tracker.set_value(sql_last_value)
           end
         rescue Sequel::Error, Java::JavaSql::SQLException => e
-          # Connection-level errors from open_jdbc_connection are already logged
-          # by jdbc_connect's internal retry loop — just let ensure clean up.
+          log_jdbc_query_exception(e)
         ensure
           close_jdbc_connection
         end

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -222,30 +222,35 @@ module LogStash  module PluginMixins module Jdbc
 
       @connection_lock.synchronize do
         begin
-          retry_attempts -= 1
           open_jdbc_connection
-          sql_last_value = @use_column_value ? @value_tracker.value : Time.now.utc
-          @tracking_column_warning_sent = false
-          @statement_handler.perform_query(@database, @value_tracker.value) do |row|
-            sql_last_value = get_column_value(row) if @use_column_value
-            yield extract_values_from(row)
-          end
-          success = true
-        rescue Sequel::Error, Java::JavaSql::SQLException => e
-          details = { exception: e.class, message: e.message }
-          details[:cause] = e.cause.inspect if e.cause
-          details[:backtrace] = e.backtrace if @logger.debug?
-          @logger.warn("Exception when executing JDBC query", details)
+          begin
+            retry_attempts -= 1
+            sql_last_value = @use_column_value ? @value_tracker.value : Time.now.utc
+            @tracking_column_warning_sent = false
+            @statement_handler.perform_query(@database, @value_tracker.value) do |row|
+              sql_last_value = get_column_value(row) if @use_column_value
+              yield extract_values_from(row)
+            end
+            success = true
+          rescue Sequel::Error, Java::JavaSql::SQLException => e
+            details = { exception: e.class, message: e.message }
+            details[:cause] = e.cause.inspect if e.cause
+            details[:backtrace] = e.backtrace if @logger.debug?
+            @logger.warn("Exception when executing JDBC query", details)
 
-          if retry_attempts == 0
-            @logger.error("Unable to execute statement. Tried #{@statement_retry_attempts} times.")
+            if retry_attempts == 0
+              @logger.error("Unable to execute statement. Tried #{@statement_retry_attempts} times.")
+            else
+              @logger.error("Unable to execute statement. Trying again.")
+              sleep(@statement_retry_attempts_wait_time)
+              retry
+            end
           else
-            @logger.error("Unable to execute statement. Trying again.")
-            sleep(@statement_retry_attempts_wait_time)
-            retry
+            @value_tracker.set_value(sql_last_value)
           end
-        else
-          @value_tracker.set_value(sql_last_value)
+        rescue Sequel::Error, Java::JavaSql::SQLException => e
+          # Connection-level errors from open_jdbc_connection are already logged
+          # by jdbc_connect's internal retry loop — just let ensure clean up.
         ensure
           close_jdbc_connection
         end

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1448,6 +1448,58 @@ describe LogStash::Inputs::Jdbc do
       plugin.run(queue)
       plugin.stop
     end
+
+    it "opens the connection only once across statement retries" do
+      mixin_settings['statement_retry_attempts'] = 3
+      mixin_settings['statement_retry_attempts_wait_time'] = 0
+      queue = Queue.new
+      plugin.register
+
+      handler = plugin.instance_variable_get(:@statement_handler)
+      allow(handler).to receive(:perform_query).and_raise(Sequel::PoolTimeout)
+      allow(plugin.logger).to receive(:warn)
+      allow(plugin.logger).to receive(:error)
+
+      expect(plugin).to receive(:open_jdbc_connection).once.and_call_original
+
+      plugin.run(queue)
+      plugin.stop
+    end
+
+    it "closes the connection after statement retries are exhausted" do
+      mixin_settings['statement_retry_attempts'] = 2
+      mixin_settings['statement_retry_attempts_wait_time'] = 0
+      queue = Queue.new
+      plugin.register
+
+      handler = plugin.instance_variable_get(:@statement_handler)
+      allow(handler).to receive(:perform_query).and_raise(Sequel::PoolTimeout)
+      allow(plugin.logger).to receive(:warn)
+      allow(plugin.logger).to receive(:error)
+
+      expect(plugin).to receive(:close_jdbc_connection).at_least(:once).and_call_original
+
+      plugin.run(queue)
+      plugin.stop
+    end
+
+    it "closes the connection when open_jdbc_connection fails after database is assigned" do
+      queue = Queue.new
+      plugin.register
+
+      allow(plugin).to receive(:open_jdbc_connection).and_wrap_original do |m, *args|
+        # simulate partial initialization: jdbc_connect succeeds but test_connection fails
+        plugin.instance_variable_set(:@database, db)
+        raise Sequel::DatabaseConnectionError, "test_connection failed"
+      end
+      allow(plugin.logger).to receive(:warn)
+      allow(plugin.logger).to receive(:error)
+
+      expect(plugin).to receive(:close_jdbc_connection).at_least(:once).and_call_original
+
+      plugin.run(queue)
+      plugin.stop
+    end
   end
 
   context "when encoding of some columns need to be changed" do


### PR DESCRIPTION
## Problem

Fixes #195. When a JDBC query fails and is retried, `open_jdbc_connection`  is called inside the begin..retry block. Ruby's retry does not trigger ensure, so the previous connection is overwritten without being closed, leaking a database session on each retry.

## Solution

Move `open_jdbc_connection` outside the inner retry block so the connection is opened once and reused across retries. An outer begin..ensure guarantees `close_jdbc_connection` always runs, even if `open_jdbc_connection` itself fails partway through.

## How to test

Deploy a PostgreSQL (or any other DB) instance via Docker Compose (or any other method) with `statement_timeout=1000` (1 second) so any query that runs longer is cancelled by the server. Then run Logstash with a JDBC input that intentionally executes a longer query and configures multiple retry attempts:

```
input {
  jdbc {
    jdbc_driver_class      => "org.postgresql.Driver"
    jdbc_connection_string => "jdbc:postgresql://localhost:15432/testdb"
    jdbc_user              => "logstash"
    jdbc_password          => "logstash"

    # Query that sleeps 10s — will be cancelled by PostgreSQL's 1s statement_timeout
    statement => "SELECT *, pg_sleep(10) FROM test_table"

    # Force multiple retries to amplify the leak
    statement_retry_attempts           => 5
    statement_retry_attempts_wait_time => 1
  }
}

output { stdout { codec => dots } }
```

While Logstash runs, monitor sessions on the database:

```
SELECT state, count(*)
FROM pg_stat_activity
WHERE usename = 'logstash'
GROUP BY state;
```

### Expected results

- **Without the fix:** every retry opens a new connection. Idle sessions accumulate on the server (0 → 1 → 2 → 3 → 4 → 5).
- **With the fix:** the same connection is reused across all retries. Only one session exists at a time, and it is cleanly closed once the plugin finishes.

Reproduction scripts (Docker Compose file, init SQL, driver, monitor script) are available on request.