### PR TITLE
Prevent concurrent Sequel JDBC subadapter initialization races by preloading adapter at driver load time

### DIFF
--- a/lib/logstash/plugin_mixins/jdbc/common.rb
+++ b/lib/logstash/plugin_mixins/jdbc/common.rb
@@ -32,6 +32,7 @@ module LogStash module PluginMixins module Jdbc
       # concurrency related problems with multiple pipelines and multiple drivers
       DRIVERS_LOADING_LOCK.lock()
       begin
+        preload_sequel_jdbc_subadapter
         load_driver_jars
         begin
           @driver_impl = load_jdbc_driver_class
@@ -48,6 +49,23 @@ module LogStash module PluginMixins module Jdbc
       ensure
         DRIVERS_LOADING_LOCK.unlock()
       end
+    end
+
+    def preload_sequel_jdbc_subadapter
+      subadapter = jdbc_subadapter_scheme
+      return unless subadapter
+
+      # Ensure first-time Sequel jdbc/<subadapter> loading happens serially.
+      Sequel::Database.load_adapter(subadapter, :map => Sequel::JDBC::DATABASE_SETUP, :subdir => 'jdbc')
+    rescue Sequel::AdapterNotFound
+      # Some JDBC URLs can work without a dedicated Sequel sub-adapter.
+      nil
+    end
+
+    def jdbc_subadapter_scheme
+      return nil unless @jdbc_connection_string
+
+      @jdbc_connection_string[/\Ajdbc:([^:]+):/, 1]&.to_sym
     end
 
     def load_driver_jars

--- a/lib/logstash/plugin_mixins/jdbc/common.rb
+++ b/lib/logstash/plugin_mixins/jdbc/common.rb
@@ -65,7 +65,7 @@ module LogStash module PluginMixins module Jdbc
     def jdbc_subadapter_scheme
       return nil unless @jdbc_connection_string
 
-      @jdbc_connection_string[/\Ajdbc:([^:]+):/, 1]&.to_sym
+      @jdbc_connection_string[/\Ajdbc:([^:]+):/, 1]&.downcase&.to_sym
     end
 
     def load_driver_jars

--- a/lib/logstash/plugin_mixins/jdbc/common.rb
+++ b/lib/logstash/plugin_mixins/jdbc/common.rb
@@ -59,6 +59,7 @@ module LogStash module PluginMixins module Jdbc
       Sequel::Database.load_adapter(subadapter, :map => Sequel::JDBC::DATABASE_SETUP, :subdir => 'jdbc')
     rescue Sequel::AdapterNotFound
       # Some JDBC URLs can work without a dedicated Sequel sub-adapter.
+      @logger.debug("Skipping Sequel JDBC sub-adapter preload", :subadapter => subadapter, :jdbc_connection_string => @jdbc_connection_string)
       nil
     end
 

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1913,10 +1913,24 @@ describe LogStash::Inputs::Jdbc do
       allow(plugin).to receive(:load_jdbc_driver_class).and_return(double("driver_class"))
     end
 
+    it "extracts jdbc sub-adapter scheme in lowercase" do
+      plugin.instance_variable_set(:@jdbc_connection_string, "jdbc:Oracle:thin:@//localhost:1521/FREEPDB1")
+
+      expect(plugin.send(:jdbc_subadapter_scheme)).to eq(:oracle)
+    end
+
     it "preloads sequel jdbc sub-adapter for jdbc URLs" do
       expect(Sequel::Database).to receive(:load_adapter).with(:derby, :map => Sequel::JDBC::DATABASE_SETUP, :subdir => 'jdbc').and_call_original
 
       plugin.send(:load_driver)
+    end
+
+    it "uses normalized jdbc sub-adapter scheme while preloading" do
+      plugin.instance_variable_set(:@jdbc_connection_string, "jdbc:Oracle:thin:@//localhost:1521/FREEPDB1")
+
+      expect(Sequel::Database).to receive(:load_adapter).with(:oracle, :map => Sequel::JDBC::DATABASE_SETUP, :subdir => 'jdbc').and_return(nil)
+
+      expect { plugin.send(:load_driver) }.not_to raise_error
     end
 
     it "does not try to preload when URL is not jdbc" do

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1907,4 +1907,40 @@ describe LogStash::Inputs::Jdbc do
       end
     end
   end
+
+  describe "jdbc adapter preloading", :no_connection do
+    before do
+      allow(plugin).to receive(:load_jdbc_driver_class).and_return(double("driver_class"))
+    end
+
+    it "preloads sequel jdbc sub-adapter for jdbc URLs" do
+      expect(Sequel::Database).to receive(:load_adapter).with(:derby, :map => Sequel::JDBC::DATABASE_SETUP, :subdir => 'jdbc').and_call_original
+
+      plugin.send(:load_driver)
+    end
+
+    it "does not try to preload when URL is not jdbc" do
+      plugin.instance_variable_set(:@jdbc_connection_string, "mock://localhost:1527/db")
+
+      expect(Sequel::Database).not_to receive(:load_adapter)
+
+      plugin.send(:load_driver)
+    end
+
+    it "ignores unknown jdbc sub-adapters" do
+      plugin.instance_variable_set(:@jdbc_connection_string, "jdbc:unknown://localhost:1527/db")
+
+      expect(Sequel::Database).to receive(:load_adapter).with(:unknown, :map => Sequel::JDBC::DATABASE_SETUP, :subdir => 'jdbc').and_raise(Sequel::AdapterNotFound)
+
+      expect { plugin.send(:load_driver) }.not_to raise_error
+    end
+
+    it "treats nil-returning jdbc sub-adapter load as a no-op" do
+      plugin.instance_variable_set(:@jdbc_connection_string, "jdbc:unknown://localhost:1527/db")
+
+      expect(Sequel::Database).to receive(:load_adapter).with(:unknown, :map => Sequel::JDBC::DATABASE_SETUP, :subdir => 'jdbc').and_return(nil)
+
+      expect { plugin.send(:load_driver) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Fixes an intermittent startup race where multiple `jdbc` inputs connecting concurrently can fail with:

- `NameError: uninitialized constant Sequel::JDBC::Oracle::DatabaseMethods`

Fixes #202.

## Problem
Since connections are opened in the input run phase (per-input thread), several `jdbc` inputs in the same pipeline can call `Sequel.connect` for the same JDBC scheme at nearly the same time on first use.

Sequel lazily loads JDBC subadapters (`jdbc/oracle`, `jdbc/mssql`, etc.). During that first-load window, another thread can observe partially initialized subadapter state and hit a `NameError` while constants are still being defined.

This is timing-dependent and intermittent, which is why reruns often succeed.

## Solution applied
During `load_driver` (register-time path already protected by `DRIVERS_LOADING_LOCK`), preload the Sequel JDBC subadapter derived from the JDBC connection string scheme.

Implementation details:
- Parse subadapter scheme from the JDBC URL (e.g. `jdbc:oracle:...` -> `:oracle`).
- Call Sequel adapter preload with:
  - `Sequel::Database.load_adapter(subadapter, map: Sequel::JDBC::DATABASE_SETUP, subdir: 'jdbc')`
- Keep behavior tolerant when no dedicated subadapter is available:
  - rescue `Sequel::AdapterNotFound` and continue (generic JDBC path still works for some DBs).

This preserves the intended behavior of not opening DB connections during register while ensuring first-time adapter code loading cannot race in run-phase worker threads.

## Manual testing
Manual repro followed the issue’s reproduction approach (multiple jdbc inputs to same Oracle DB, repeated fresh starts), with an amplified stress scenario.

### Setup
- Oracle DB via Docker (`gvenzl/oracle-free:23-slim`)
- Oracle JDBC driver jar downloaded and used by pipeline
- Generated stress pipeline with 40 concurrent `jdbc` input blocks (same DB, different `select <n> from dual` statements)
- Logstash started repeatedly with fresh `--path.data`

### Reproduce on pre-fix state
Using the same stress scenario:
- 40 inputs, 8 workers
- repeated runs until hit
- reproduced on run 12
- observed multiple occurrences of:
  - `uninitialized constant Sequel::JDBC::Oracle::DatabaseMethods`
  - `Exception: NameError`

### Verify on fixed state
Same scenario, same environment:
- 40 inputs, 8 workers
- 100-run stress pass: 0 `NameError` hits

Result: the race reproduces before the change and is not observed after the change under identical stress conditions.
